### PR TITLE
Add foundational time and turn systems

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,29 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { ITEMS_CATALOG } from "./data/items";
 import { GAME_NOTES, GameNote } from "./data/notes";
 import { decisionCards as decisionData } from "./data/decisionCards";
+import TurnOverlay from "./components/TurnOverlay";
+import CountdownBar from "./components/CountdownBar";
+import {
+  createTimeState,
+  tickTime,
+  applyTimeCost,
+  shouldAdvanceDay,
+  advanceDay,
+} from "./systems/time";
+import {
+  createTurnState,
+  resetCupos,
+  nextPlayer,
+  type PlayerCupos,
+} from "./systems/turns";
+import {
+  type CombatActor,
+  setCooldown,
+  tickCooldown,
+  enemyImmediateStrike,
+  dealDamage,
+  isAlive,
+} from "./systems/combat";
 
 // === Tipos ===
 type Phase = "dawn" | "day" | "dusk" | "night";
@@ -22,6 +45,7 @@ type Player = {
   ammo: number;
   inventory: string[];
   attrs: Attributes;
+  cupos: PlayerCupos;
 };
 
 type Enemy = { id: string; name: string; hp: number; hpMax: number; def: number; atk: number; special?: string; };
@@ -263,7 +287,8 @@ export default function App(){
       status: "ok",
       ammo: 20,
       inventory: ["Navaja"],
-      attrs
+      attrs,
+      cupos: resetCupos(),
     };
   }
 

--- a/src/components/CountdownBar.tsx
+++ b/src/components/CountdownBar.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+type Props = {
+  currentMs: number;
+  maxMs: number;
+  label?: string;
+};
+
+export default function CountdownBar({ currentMs, maxMs, label }: Props) {
+  const pct = Math.max(0, Math.min(100, 100 - (currentMs / Math.max(1, maxMs)) * 100));
+  return (
+    <div className="w-full">
+      {label && <div className="text-xs mb-1 opacity-80">{label}</div>}
+      <div className="w-full h-2 bg-gray-800/60 rounded overflow-hidden border border-gray-700">
+        <div
+          className="h-full bg-gradient-to-r from-emerald-500 to-emerald-300 transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/TurnOverlay.tsx
+++ b/src/components/TurnOverlay.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+type Props = {
+  visible: boolean;
+  playerName: string;
+  onStart: () => void;
+};
+
+export default function TurnOverlay({ visible, playerName, onStart }: Props) {
+  if (!visible) return null;
+  return (
+    <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-50 flex items-center justify-center p-6">
+      <div className="max-w-md w-full bg-zinc-900/90 border border-zinc-700 rounded-2xl p-6 text-center shadow-2xl">
+        <h2 className="text-2xl font-bold mb-2">Es el turno de:</h2>
+        <p className="text-3xl font-extrabold text-emerald-400 mb-6">{playerName}</p>
+        <button
+          onClick={onStart}
+          className="px-6 py-3 rounded-xl bg-emerald-600 hover:bg-emerald-500 font-semibold shadow"
+        >
+          Comenzar turno
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/systems/combat.ts
+++ b/src/systems/combat.ts
@@ -1,0 +1,38 @@
+export type CombatActor = {
+  id: string;
+  name: string;
+  hp: number;
+  maxHp: number;
+  baseCooldownMs: number;
+  actionCooldownMs: number;
+  isDefending?: boolean;
+};
+
+export const ENEMY_CRIT_RATE_ON_PLAYER_PASSIVE = 0.5;
+export const CRIT_MULTIPLIER = 1.5;
+export const DEFEND_REDUCTION = 0.35;
+
+export function isAlive(a: CombatActor) {
+  return a.hp > 0;
+}
+
+export function setCooldown(a: CombatActor) {
+  a.actionCooldownMs = a.baseCooldownMs;
+}
+
+export function tickCooldown(a: CombatActor, deltaMs: number) {
+  a.actionCooldownMs = Math.max(0, a.actionCooldownMs - deltaMs);
+}
+
+export function dealDamage(target: CombatActor, base: number, crit = false, defending = false) {
+  let dmg = crit ? Math.round(base * CRIT_MULTIPLIER) : base;
+  if (defending) dmg = Math.max(0, Math.round(dmg * (1 - DEFEND_REDUCTION)));
+  target.hp = Math.max(0, target.hp - dmg);
+  return dmg;
+}
+
+export function enemyImmediateStrike(enemy: CombatActor, player: CombatActor, baseDamage: number) {
+  const crit = Math.random() < ENEMY_CRIT_RATE_ON_PLAYER_PASSIVE;
+  const dmg = dealDamage(player, baseDamage, crit, !!player.isDefending);
+  return { crit, dmg };
+}

--- a/src/systems/time.ts
+++ b/src/systems/time.ts
@@ -1,0 +1,41 @@
+export type TimeState = {
+  day: number;
+  dayClockMs: number;
+  dayLengthMs: number;
+  tickIntervalMs: number;
+};
+
+export const DAY_LENGTH_MINUTES = 20;
+export const DEFAULT_TICK_MS = 500;
+
+export const ACTION_TIME_COSTS = {
+  explore: 30_000,
+  battle: 20_000,
+  decision: 10_000,
+};
+
+export function createTimeState(): TimeState {
+  return {
+    day: 1,
+    dayClockMs: DAY_LENGTH_MINUTES * 60_000,
+    dayLengthMs: DAY_LENGTH_MINUTES * 60_000,
+    tickIntervalMs: DEFAULT_TICK_MS,
+  };
+}
+
+export function tickTime(state: TimeState) {
+  state.dayClockMs = Math.max(0, state.dayClockMs - state.tickIntervalMs);
+}
+
+export function applyTimeCost(state: TimeState, kind: keyof typeof ACTION_TIME_COSTS) {
+  state.dayClockMs = Math.max(0, state.dayClockMs - ACTION_TIME_COSTS[kind]);
+}
+
+export function shouldAdvanceDay(state: TimeState) {
+  return state.dayClockMs <= 0;
+}
+
+export function advanceDay(state: TimeState) {
+  state.day += 1;
+  state.dayClockMs = state.dayLengthMs;
+}

--- a/src/systems/turns.ts
+++ b/src/systems/turns.ts
@@ -1,0 +1,31 @@
+export type PlayerCupos = {
+  decisionsLeft: number;
+  battlesLeft: number;
+  explorationsLeft: number;
+};
+
+export const DEFAULT_CUPOS: PlayerCupos = {
+  decisionsLeft: 2,
+  battlesLeft: 4,
+  explorationsLeft: 5,
+};
+
+export type TurnState = {
+  activeIndex: number;
+  turnNumber: number;
+  overlay: boolean;
+};
+
+export function createTurnState(): TurnState {
+  return { activeIndex: 0, turnNumber: 1, overlay: true };
+}
+
+export function resetCupos(): PlayerCupos {
+  return { ...DEFAULT_CUPOS };
+}
+
+export function nextPlayer(turn: TurnState, playersLen: number) {
+  turn.activeIndex = (turn.activeIndex + 1) % playersLen;
+  if (turn.activeIndex === 0) turn.turnNumber += 1;
+  turn.overlay = true;
+}


### PR DESCRIPTION
## Summary
- add countdown bar and turn overlay components
- introduce time, turn, and combat system utilities
- extend player model with per-turn quotas

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b63ead8f708325894593b5c7e4c9c9