### PR TITLE
feat: add character creation mode and game clock pause

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "clsx": "^2.1.1"
+    "clsx": "^2.1.1",
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/hooks/useGameClock.ts
+++ b/src/hooks/useGameClock.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useGameStore } from "@/state/gameStore";
+
+export function useGameClock() {
+  const paused = useGameStore((s) => s.ui.paused);
+  const mode = useGameStore((s) => s.ui.mode);
+  const tick = useGameStore((s) => s.tick);
+
+  useEffect(() => {
+    if (paused || mode === "character-creation") return;
+
+    const id = setInterval(() => {
+      tick(1000);
+    }, 1000);
+
+    return () => clearInterval(id);
+  }, [paused, mode, tick]);
+}

--- a/src/state/gameStore.ts
+++ b/src/state/gameStore.ts
@@ -1,0 +1,51 @@
+import { create } from "zustand";
+
+export type UIMode = "character-creation" | "running" | "paused";
+
+export type Player = {
+  id: string;
+  name: string;
+  profession: string;
+  bio: string;
+};
+
+export type UIState = {
+  mode: UIMode;
+  paused: boolean;
+  characterInitial?: {
+    id: string;
+    name?: string;
+    profession?: string;
+    bio?: string;
+  } | null;
+};
+
+export type GameState = {
+  ui: UIState;
+  players: Player[];
+  tick: (ms: number) => void;
+  setMode: (m: UIMode) => void;
+  createPlayer: (p: Omit<Player, "id">) => void;
+};
+
+export const useGameStore = create<GameState>((set, get) => ({
+  ui: { mode: "character-creation", paused: true },
+  players: [],
+  tick: (ms) => {
+    const { ui } = get();
+    if (ui.mode === "character-creation" || ui.paused) return;
+    // advance game clock here
+  },
+  setMode: (m) =>
+    set((state) => ({
+      ui: {
+        ...state.ui,
+        mode: m,
+        paused: m === "running" ? false : true,
+      },
+    })),
+  createPlayer: (p) =>
+    set((state) => ({
+      players: [...state.players, { id: crypto.randomUUID(), ...p }],
+    })),
+}));

--- a/src/ui/CharacterCreationPanel.tsx
+++ b/src/ui/CharacterCreationPanel.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useGameStore } from "@/state/gameStore";
+
+type Draft = {
+  name: string;
+  profession: string;
+  bio: string;
+};
+
+const PROFESSIONS = [
+  "Médico/a",
+  "Mecánico/a",
+  "Docente",
+  "Scout",
+  "Carpintero/a",
+  "Enfermero/a",
+  "Ingeniero/a",
+  "Agricultor/a",
+];
+
+export default function CharacterCreationPanel() {
+  const ui = useGameStore((s) => s.ui);
+  const createPlayer = useGameStore((s) => s.createPlayer);
+  const setMode = useGameStore((s) => s.setMode);
+  const hasPlayers = useGameStore((s) => s.players.length > 0);
+
+  const [draft, setDraft] = useState<Draft>({
+    name: "",
+    profession: "",
+    bio: "",
+  });
+
+  const initial = useGameStore((s) => s.ui.characterInitial || null);
+  const prevInitialId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (initial && initial.id !== prevInitialId.current) {
+      setDraft({
+        name: initial.name ?? "",
+        profession: initial.profession ?? "",
+        bio: initial.bio ?? "",
+      });
+      prevInitialId.current = initial.id;
+    }
+  }, [initial]);
+
+  function onChange<K extends keyof Draft>(key: K, value: Draft[K]) {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function randomizeProfessionOnce() {
+    if (!draft.profession) {
+      const r = PROFESSIONS[Math.floor(Math.random() * PROFESSIONS.length)];
+      setDraft((prev) => ({ ...prev, profession: r }));
+    }
+  }
+
+  function handleCreate() {
+    const name = draft.name.trim();
+    const profession = draft.profession.trim();
+    if (!name || !profession) return;
+
+    createPlayer({
+      name,
+      profession,
+      bio: draft.bio.trim(),
+    });
+
+    setDraft({ name: "", profession: "", bio: "" });
+  }
+
+  function handleStart() {
+    if (!hasPlayers) return;
+    setMode("running");
+  }
+
+  return (
+    <div className="p-4 max-w-xl mx-auto space-y-4">
+      <h2 className="text-xl font-bold">Crear Personaje</h2>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium">Nombre</label>
+        <input
+          className="w-full border rounded px-3 py-2"
+          placeholder="Ingresa nombre…"
+          value={draft.name}
+          onChange={(e) => onChange("name", e.target.value)}
+          onFocus={randomizeProfessionOnce}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium">Profesión</label>
+        <select
+          className="w-full border rounded px-3 py-2"
+          value={draft.profession}
+          onChange={(e) => onChange("profession", e.target.value)}
+        >
+          <option value="">Selecciona…</option>
+          {PROFESSIONS.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="space-y-2">
+        <label className="block text-sm font-medium">Bio</label>
+        <textarea
+          className="w-full border rounded px-3 py-2 h-28"
+          placeholder="Breve historia / rasgos…"
+          value={draft.bio}
+          onChange={(e) => onChange("bio", e.target.value)}
+        />
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          className="px-4 py-2 rounded bg-blue-600 text-white"
+          onClick={handleCreate}
+        >
+          Crear personaje
+        </button>
+
+        <button
+          className="px-4 py-2 rounded bg-green-600 text-white disabled:opacity-50"
+          onClick={handleStart}
+          disabled={!hasPlayers}
+        >
+          Iniciar
+        </button>
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Sugerencia: crea varios personajes y luego pulsa “Iniciar”. El juego permanece en pausa durante la creación.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Zustand game store with character creation mode and pause logic
- implement useGameClock hook to stop ticking during character creation
- add CharacterCreationPanel with local draft state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b649ad41948325921ed0c730d2b605