### PR TITLE
Prefill character creation with default draft and toast

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+
+// Simple toast system: call toast(message) to show
+// Positioned at bottom-right, auto hides after ~3.5s
+
+type ToastState = { id: number; text: string } | null;
+
+let trigger: ((msg: string) => void) | null = null;
+
+export function toast(msg: string) {
+  trigger?.(msg);
+}
+
+export function ToastContainer() {
+  const [toastState, setToastState] = useState<ToastState>(null);
+
+  useEffect(() => {
+    trigger = (msg: string) => setToastState({ id: Date.now(), text: msg });
+    return () => {
+      trigger = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!toastState) return;
+    const id = setTimeout(() => setToastState(null), 3500);
+    return () => clearTimeout(id);
+  }, [toastState]);
+
+  if (!toastState) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-black text-white px-4 py-2 rounded shadow" key={toastState.id}>
+      {toastState.text}
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,12 +4,14 @@ import { createRoot } from 'react-dom/client'
 import App from './App'
 import './styles.css'
 import { LevelProvider } from '@/state/levelStore'
+import { ToastContainer } from '@/components/Toast'
 
 const root = createRoot(document.getElementById('root')!)
 root.render(
   <React.StrictMode>
     <LevelProvider>
       <App />
+      <ToastContainer />
     </LevelProvider>
   </React.StrictMode>
 )

--- a/src/ui/CharacterCreationPanel.tsx
+++ b/src/ui/CharacterCreationPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useGameStore } from "@/state/gameStore";
+import { toast } from "@/components/Toast";
 
 type Draft = {
   name: string;
@@ -18,6 +19,9 @@ const PROFESSIONS = [
   "Agricultor/a",
 ];
 
+// evita toasts duplicados en la sesión
+let toastShown = false;
+
 export default function CharacterCreationPanel() {
   const ui = useGameStore((s) => s.ui);
   const createPlayer = useGameStore((s) => s.createPlayer);
@@ -25,8 +29,8 @@ export default function CharacterCreationPanel() {
   const hasPlayers = useGameStore((s) => s.players.length > 0);
 
   const [draft, setDraft] = useState<Draft>({
-    name: "",
-    profession: "",
+    name: "Sara", // borrador inicial
+    profession: "", // valor por defecto del select
     bio: "",
   });
 
@@ -43,6 +47,16 @@ export default function CharacterCreationPanel() {
       prevInitialId.current = initial.id;
     }
   }, [initial]);
+
+  // disparar toast una sola vez al montar
+  useEffect(() => {
+    if (!toastShown) {
+      toast(
+        "¡Personaje inicial creado! Puedes cambiar el nombre, elegir una profesión y escribir la bio cuando quieras."
+      );
+      toastShown = true;
+    }
+  }, []);
 
   function onChange<K extends keyof Draft>(key: K, value: Draft[K]) {
     setDraft((prev) => ({ ...prev, [key]: value }));
@@ -142,3 +156,11 @@ export default function CharacterCreationPanel() {
     </div>
   );
 }
+
+/*
+Manual test:
+1. Abrir "Crear personaje" → Nombre = "Sara", profesión por defecto, bio vacía.
+2. Aparece un toast con el mensaje indicado y desaparece solo.
+3. Se pueden editar Nombre/Profesión/Bio normalmente.
+4. Al volver a la pantalla en la misma sesión, no se repite el toast.
+*/


### PR DESCRIPTION
## Summary
- Prefill character creation form with name "Sara" and blank profession/bio
- Add minimal toast system and show one-time notification when screen mounts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b660974570832594b2ec6d1915da60