### PR TITLE
Add start screen and refine character creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import {
 import { useLevel } from "@/state/levelStore";
 import { DayHud } from "@/components/hud/DayHud";
 import { TurnTransitionModal } from "@/components/overlays/TurnTransitionModal";
+import StartScreen from "@/ui/StartScreen";
 
 // === Tipos ===
 type Phase = "dawn" | "day" | "dusk" | "night";
@@ -183,6 +184,7 @@ const EXPLORATION_EVENTS: ExplorationEvent[] = [
 export default function App(){
   // Estado base
   const [state, setState] = useState<GameState>("menu");
+  const [showStart, setShowStart] = useState(true);
   const [day, setDay] = useState(1);
   const [phase, setPhase] = useState<Phase>("dawn");
   const [clockMs, setClockMs] = useState<number>(DAY_LENGTH_MS);
@@ -197,6 +199,10 @@ export default function App(){
   const [roster, setRoster] = useState<Player[]>([]);
   const [turn, setTurn] = useState(0);
   const alivePlayers = useMemo(()=>players.filter(p=>p.status!=="dead"), [players]);
+
+  if (showStart) {
+    return <StartScreen onStart={() => { setShowStart(false); setState('setup'); }} />;
+  }
 
   // Mazo de cartas
   const [decisionDeck, setDecisionDeck] = useState<Card[]>(shuffle([...decisionDeckSeed]));

--- a/src/ui/CharacterCreationPanel.tsx
+++ b/src/ui/CharacterCreationPanel.tsx
@@ -1,160 +1,129 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useGameStore } from "@/state/gameStore";
-import { toast } from "@/components/Toast";
 
-type Draft = {
-  name: string;
-  profession: string;
-  bio: string;
-};
+type Draft = { name: string; profession: string; bio: string };
 
 const PROFESSIONS = [
-  "Médico/a",
-  "Mecánico/a",
-  "Docente",
-  "Scout",
-  "Carpintero/a",
-  "Enfermero/a",
-  "Ingeniero/a",
-  "Agricultor/a",
+  "Médico/a","Mecánico/a","Docente","Scout","Carpintero/a","Enfermero/a",
+  "Bombero/a","Cocinero/a","Agricultor/a","Electricista","Policía","Militar"
 ];
 
-// evita toasts duplicados en la sesión
-let toastShown = false;
-
 export default function CharacterCreationPanel() {
-  const ui = useGameStore((s) => s.ui);
-  const createPlayer = useGameStore((s) => s.createPlayer);
-  const setMode = useGameStore((s) => s.setMode);
-  const hasPlayers = useGameStore((s) => s.players.length > 0);
+  const { ui, players, createPlayer, setMode } = useGameStore();
+  const [draft, setDraft] = useState<Draft>({ name: "", profession: PROFESSIONS[0], bio: "" });
+  const seededOnce = useRef(false);
 
-  const [draft, setDraft] = useState<Draft>({
-    name: "",
-    profession: "", // valor por defecto del select
-    bio: "",
-  });
-
-  const initial = useGameStore((s) => s.ui.characterInitial || null);
-
+  // Prefill SOLO si el usuario aún no escribió nada
   useEffect(() => {
-    if (!initial) return;
-    setDraft((prev) => {
-      const userTyped =
-        prev.name.trim() || prev.profession.trim() || prev.bio.trim();
-      if (userTyped) return prev; // no pisar si ya escribió
-      return {
-        name: initial.name ?? "",
-        profession: initial.profession ?? "",
-        bio: initial.bio ?? "",
-      };
-    });
-  }, [initial]);
-
-  // disparar toast una sola vez al montar
-  useEffect(() => {
-    if (!toastShown) {
-      toast(
-        "¡Personaje inicial creado! Puedes cambiar el nombre, elegir una profesión y escribir la bio cuando quieras."
-      );
-      toastShown = true;
+    if (seededOnce.current) return;
+    if (!draft.name.trim() && !draft.bio.trim()) {
+      if (ui?.characterInitial) {
+        setDraft({
+          name: ui.characterInitial.name ?? "Sara",
+          profession: ui.characterInitial.profession ?? PROFESSIONS[0],
+          bio: ui.characterInitial.bio ?? "",
+        });
+      } else {
+        setDraft((prev) => ({ ...prev, name: "Sara" }));
+      }
+      seededOnce.current = true;
     }
-  }, []);
+  }, [ui?.characterInitial, draft.name, draft.bio]);
 
-  function onChange<K extends keyof Draft>(key: K, value: Draft[K]) {
-    setDraft((prev) => ({ ...prev, [key]: value }));
-  }
+  const onChange = (k: keyof Draft, v: string) => setDraft(prev => ({ ...prev, [k]: v }));
 
-  function randomizeProfessionOnce() {
-    if (!draft.profession) {
-      const r = PROFESSIONS[Math.floor(Math.random() * PROFESSIONS.length)];
-      setDraft((prev) => ({ ...prev, profession: r }));
-    }
-  }
+  const handleAdd = () => {
+    const nm = draft.name.trim();
+    if (!nm) return;
+    createPlayer({ name: nm, profession: draft.profession, bio: draft.bio });
+    setDraft({ name: "", profession: PROFESSIONS[0], bio: "" });
+    seededOnce.current = false; // permite prefill de nuevo si vuelves a entrar
+  };
 
-  function handleCreate() {
-    const name = draft.name.trim();
-    const profession = draft.profession.trim();
-    if (!name || !profession) return;
+  const handleStart = () => {
+    if (players.length > 0) setMode("running");
+  };
 
-    createPlayer({
-      name,
-      profession,
-      bio: draft.bio.trim(),
-    });
+  // Bloquea atajos globales mientras estás en esta pantalla
+  const stopAllKeysCapture: React.KeyboardEventHandler = (e) => {
+    // Evita submits fantasmas
+    if (e.key === "Enter") e.preventDefault();
+    e.stopPropagation();
+  };
 
-    setDraft({ name: "", profession: "", bio: "" });
-  }
-
-  function handleStart() {
-    if (!hasPlayers) return;
-    setMode("running");
-  }
+  const hasPlayers = players.length > 0;
 
   return (
-    <div className="p-4 max-w-xl mx-auto space-y-4">
-      <h2 className="text-xl font-bold">Crear Personaje</h2>
+    <div
+      className="max-w-2xl mx-auto card card-red p-6 space-y-6 animate-fade-in"
+      // Captura antes que burbujee a listeners globales
+      onKeyDownCapture={stopAllKeysCapture}
+      onKeyUpCapture={(e) => e.stopPropagation()}
+      onKeyPressCapture={(e) => e.stopPropagation()}
+    >
+      <h2 className="text-2xl font-bold">Crear personaje</h2>
 
-      <div className="space-y-2">
-        <label htmlFor="player-name" className="block text-sm font-medium">
-          Nombre
-        </label>
-        <input
-          id="player-name"
-          name="playerName"
-          className="w-full border rounded px-3 py-2"
-          type="text"
-          placeholder="Ingresa nombre…"
-          value={draft.name}
-          onChange={(e) => onChange("name", e.target.value)}
-          onFocus={randomizeProfessionOnce}
-          onKeyDown={(e) => e.stopPropagation()} // evita que los atajos globales intercepten la escritura
-        />
+      <div className="grid gap-4">
+        {/* Nombre */}
+        <div>
+          <label htmlFor="player-name" className="block text-sm font-medium">Nombre</label>
+          <input
+            id="player-name"
+            name="playerName"
+            type="text"
+            autoComplete="off"
+            className="w-full border rounded px-3 py-2"
+            placeholder="Ingresa nombre…"
+            value={draft.name}
+            onChange={(e) => onChange("name", e.target.value)}
+            onKeyDown={stopAllKeysCapture}
+          />
+        </div>
+
+        {/* Profesión */}
+        <div>
+          <label htmlFor="player-profession" className="block text-sm font-medium">Profesión</label>
+          <select
+            id="player-profession"
+            name="playerProfession"
+            className="w-full border rounded px-3 py-2"
+            value={draft.profession}
+            onChange={(e) => onChange("profession", e.target.value)}
+            onKeyDown={stopAllKeysCapture}
+          >
+            {PROFESSIONS.map((p) => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Bio */}
+        <div>
+          <label htmlFor="player-bio" className="block text-sm font-medium">Bio</label>
+          <textarea
+            id="player-bio"
+            name="playerBio"
+            className="w-full border rounded px-3 py-2 h-28"
+            placeholder="Breve historia / rasgos…"
+            value={draft.bio}
+            onChange={(e) => onChange("bio", e.target.value)}
+            onKeyDown={stopAllKeysCapture}
+          />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            className="px-4 py-2 rounded bg-purple-600 text-white disabled:opacity-50"
+            onClick={handleAdd}
+            disabled={!draft.name.trim()}
+          >
+            Agregar
+          </button>
+          <span className="text-xs text-neutral-400">Puedes crear varios personajes antes de iniciar.</span>
+        </div>
       </div>
 
-      <div className="space-y-2">
-        <label htmlFor="player-profession" className="block text-sm font-medium">
-          Profesión
-        </label>
-        <select
-          id="player-profession"
-          name="playerProfession"
-          className="w-full border rounded px-3 py-2"
-          value={draft.profession}
-          onChange={(e) => onChange("profession", e.target.value)}
-          onKeyDown={(e) => e.stopPropagation()} // evita que los atajos globales intercepten la escritura
-        >
-          <option value="">Selecciona…</option>
-          {PROFESSIONS.map((p) => (
-            <option key={p} value={p}>
-              {p}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className="space-y-2">
-        <label htmlFor="player-bio" className="block text-sm font-medium">
-          Bio
-        </label>
-        <textarea
-          id="player-bio"
-          name="playerBio"
-          className="w-full border rounded px-3 py-2 h-28"
-          placeholder="Breve historia / rasgos…"
-          value={draft.bio}
-          onChange={(e) => onChange("bio", e.target.value)}
-          onKeyDown={(e) => e.stopPropagation()} // evita que los atajos globales intercepten la escritura
-        />
-      </div>
-
-      <div className="flex gap-2">
-        <button
-          className="px-4 py-2 rounded bg-blue-600 text-white"
-          onClick={handleCreate}
-        >
-          Crear personaje
-        </button>
-
+      <div className="flex justify-end gap-3">
         <button
           className="px-4 py-2 rounded bg-green-600 text-white disabled:opacity-50"
           onClick={handleStart}
@@ -171,10 +140,3 @@ export default function CharacterCreationPanel() {
   );
 }
 
-/*
-Manual test:
-1. Abrir "Crear personaje" → Nombre = "Sara", profesión por defecto, bio vacía.
-2. Aparece un toast con el mensaje indicado y desaparece solo.
-3. Se pueden editar Nombre/Profesión/Bio normalmente.
-4. Al volver a la pantalla en la misma sesión, no se repite el toast.
-*/

--- a/src/ui/StartScreen.tsx
+++ b/src/ui/StartScreen.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+export default function StartScreen({ onStart }: { onStart: () => void }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="card card-red max-w-2xl w-full p-6 space-y-6 animate-fade-in">
+        <h1 className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-red-400 to-red-600">
+          Apocalipsis Zombie RPG
+        </h1>
+
+        <div className="space-y-3 text-sm text-neutral-300">
+          <p className="text-neutral-200">Reglas rápidas:</p>
+          <ul className="list-disc ml-5 space-y-2">
+            <li>Crea uno o más personajes con nombre, profesión y bio.</li>
+            <li>Gestiona recursos y toma decisiones; cada acción consume tiempo.</li>
+            <li>El riesgo aumenta con el ruido y la amenaza del entorno.</li>
+            <li>Game Over si moral o recursos críticos llegan a 0.</li>
+          </ul>
+        </div>
+
+        <div className="flex justify-end">
+          <button className="btn btn-red px-5 py-2 rounded-2xl border border-red-800" onClick={onStart}>
+            Comenzar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace character creation panel to preserve user draft, block global key shortcuts, and add form field ids
- add animated start screen with quick rules and begin button
- route start screen in app before character creation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b66fc689fc8325a678a3176292b205