### PR TITLE
Restore main game flow and campaign start

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import StartScreen from "@/ui/StartScreen";
 import CharacterSetupPanel from "@/ui/CharacterSetupPanel";
 import DevStatusBadge from "@/components/DevStatusBadge";
+import GameRoot from "@/GameRoot";
 import { campaignStore, useCampaign } from "@/state/campaign";
 
 export default function App() {
@@ -28,10 +29,16 @@ export default function App() {
   if (state === "setup") return <CharacterSetupPanel />;
 
   return (
-    <div className="min-h-screen bg-neutral-900 text-neutral-100 p-4">
-      <h1 className="text-xl font-bold">Día {day}</h1>
-      <p>Jugadores: {roster.length}</p>
-      <DevStatusBadge state={state} showStart={showStart} playersLen={roster.length} turnIndex={0} day={day} timers={{ clock: tickEnabled, event: false }} />
-    </div>
+    <>
+      <GameRoot />
+      <DevStatusBadge
+        state={state}
+        showStart={showStart}
+        playersLen={roster.length}
+        turnIndex={0}
+        day={day}
+        timers={{ clock: tickEnabled, event: false }}
+      />
+    </>
   );
 }

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useCampaign } from "@/state/campaign";
 
 // Simple toast system: call toast(message) to show
 // Positioned at bottom-right, auto hides after ~3.5s
@@ -13,6 +14,7 @@ export function toast(msg: string) {
 
 export function ToastContainer() {
   const [toastState, setToastState] = useState<ToastState>(null);
+  const state = useCampaign((s) => s.state);
 
   useEffect(() => {
     trigger = (msg: string) => setToastState({ id: Date.now(), text: msg });
@@ -22,10 +24,10 @@ export function ToastContainer() {
   }, []);
 
   useEffect(() => {
-    if (!toastState) return;
+    if (state !== "playing" || !toastState) return;
     const id = setTimeout(() => setToastState(null), 3500);
     return () => clearTimeout(id);
-  }, [toastState]);
+  }, [toastState, state]);
 
   if (!toastState) return null;
 

--- a/src/hooks/useGameClock.ts
+++ b/src/hooks/useGameClock.ts
@@ -1,18 +1,20 @@
 import { useEffect } from "react";
 import { useGameStore } from "@/state/gameStore";
+import { useCampaign } from "@/state/campaign";
 
 export function useGameClock() {
   const paused = useGameStore((s) => s.ui.paused);
   const mode = useGameStore((s) => s.ui.mode);
   const tick = useGameStore((s) => s.tick);
+  const state = useCampaign((s) => s.state);
 
   useEffect(() => {
-    if (paused || mode === "character-creation") return;
+    if (state !== "playing" || paused || mode === "character-creation") return;
 
     const id = setInterval(() => {
       tick(1000);
     }, 1000);
 
     return () => clearInterval(id);
-  }, [paused, mode, tick]);
+  }, [state, paused, mode, tick]);
 }

--- a/src/state/levelStore.tsx
+++ b/src/state/levelStore.tsx
@@ -1,5 +1,6 @@
 // src/state/levelStore.tsx
 import React, { createContext, useContext, useMemo, useReducer, useEffect } from "react";
+import { useCampaign } from "@/state/campaign";
 import type {
   DayId, DayState, LevelContextAPI, NarrativeFlags, DayRules, DeckId, LevelEndReason
 } from "@/types/level";
@@ -177,14 +178,15 @@ export const LevelProvider: React.FC<{
   onEvent?: (e: any) => void;
 }> = ({ children, onEvent }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const gameState = useCampaign((s) => s.state);
 
   useEffect(() => {
-    if (state.flags.paused || !state.dayState.endsAt) return;
+    if (gameState !== "playing" || state.flags.paused || !state.dayState.endsAt) return;
     const t = setInterval(() => {
       dispatch({ type: "TICK", nowMs: Date.now() });
     }, 1000);
     return () => clearInterval(t);
-  }, [state.flags.paused, state.dayState.endsAt]);
+  }, [gameState, state.flags.paused, state.dayState.endsAt]);
 
   const api = useMemo<LevelContextAPI>(() => {
     const drawFrom = (deck: DeckId): number | null => {

--- a/src/ui/CharacterSetupPanel.tsx
+++ b/src/ui/CharacterSetupPanel.tsx
@@ -33,20 +33,19 @@ export default function CharacterSetupPanel() {
     seededOnce.current = false;
   };
 
-  const handleStart = () => {
-    if (!campaignStore.canStartCampaign()) {
+  const onStartCampaign = async () => {
+    if (roster.length === 0) {
       toast("Necesitas al menos un jugador");
       return;
     }
-    campaignStore.startCampaign();
+    await campaignStore.ensureDayLoaded(1);
+    campaignStore.setState("playing");
   };
 
   const stopAllKeysCapture: React.KeyboardEventHandler = (e) => {
     if (e.key === "Enter") e.preventDefault();
     e.stopPropagation();
   };
-
-  const canStart = campaignStore.canStartCampaign();
 
   return (
     <div
@@ -118,8 +117,8 @@ export default function CharacterSetupPanel() {
         <button
           type="button"
           className="px-4 py-2 rounded bg-green-600 text-white disabled:opacity-50"
-          onClick={handleStart}
-          disabled={!canStart}
+          onClick={onStartCampaign}
+          disabled={roster.length === 0}
         >
           Iniciar campaña
         </button>


### PR DESCRIPTION
## Summary
- Render the original `GameRoot` when the campaign enters playing state
- Enable campaign start to load Day 1 content and guard setup inputs
- Pause background timers outside of gameplay and improve long text rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75af09a408325881cc283a6062a25