### PR TITLE
Render full game during play state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,18 +27,20 @@ export default function App() {
   if (showStart)
     return <StartScreen onStart={() => { setShowStart(false); campaignStore.setState("setup"); }} />;
   if (state === "setup") return <CharacterSetupPanel />;
+  if (state === "playing")
+    return (
+      <>
+        <GameRoot />
+        <DevStatusBadge
+          state={state}
+          showStart={showStart}
+          playersLen={roster.length}
+          turnIndex={0}
+          day={day}
+          timers={{ clock: tickEnabled, event: false }}
+        />
+      </>
+    );
 
-  return (
-    <>
-      <GameRoot />
-      <DevStatusBadge
-        state={state}
-        showStart={showStart}
-        playersLen={roster.length}
-        turnIndex={0}
-        day={day}
-        timers={{ clock: tickEnabled, event: false }}
-      />
-    </>
-  );
+  return null;
 }

--- a/src/GameRoot.tsx
+++ b/src/GameRoot.tsx
@@ -1513,7 +1513,7 @@ function LogPanel({log}:{log:string[]}){
       <h3 className="text-xl font-bold mb-4">📜 Registro</h3>
       <div className="max-h-72 overflow-y-auto scrollbar-hide space-y-2">
         {log.length===0 ? <p className="text-neutral-500">Sin eventos aún.</p> :
-          log.map((l,i)=>(<div key={i} className="p-2 bg-neutral-800/60 rounded">{l}</div>))
+          log.map((l,i)=>(<div key={i} className="p-2 bg-neutral-800/60 rounded whitespace-pre-wrap leading-relaxed">{l}</div>))
         }
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Mount `GameRoot` and debugging badge when campaign state is `playing` instead of a stub screen
- Allow long log entries by preserving whitespace in log panel

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b75e7ded408325aaf318396227ea66