### PR TITLE
feat: add autonomous welcome overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { clsx } from "clsx";
 import { ITEMS_CATALOG } from "./data/items";
 import { GAME_NOTES, GameNote } from "./data/notes";
+import WelcomeOverlay from "./components/WelcomeOverlay";
 
 // === Tipos ===
 type Phase = "dawn" | "day" | "dusk" | "night";
@@ -851,6 +852,8 @@ export default function App(){
           </div>
         </div>
       )}
+
+      <WelcomeOverlay />
     </div>
   );
 }

--- a/src/components/WelcomeOverlay.tsx
+++ b/src/components/WelcomeOverlay.tsx
@@ -1,38 +1,120 @@
-import React from 'react'
+import React, { useEffect, useState } from "react";
 
-interface Props {
-  onStart: () => void
-  onClose: () => void
-}
+const DISMISS_KEY = "azrpg_welcome_dismissed";
 
-export default function WelcomeOverlay({ onStart, onClose }: Props) {
+export default function WelcomeOverlay() {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<"how" | "story">("how");
+
+  useEffect(() => {
+    if (localStorage.getItem(DISMISS_KEY) !== "true") {
+      setOpen(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    if (open) window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const close = () => setOpen(false);
+  const dismiss = () => {
+    localStorage.setItem(DISMISS_KEY, "true");
+    setOpen(false);
+  };
+
+  if (!open) return null;
+
   return (
-    <div className="fixed inset-0 z-[1000] flex items-center justify-center">
-      <div className="max-w-3xl w-full rounded-2xl border border-red-700 bg-black/80 backdrop-blur p-6 shadow-2xl space-y-2">
-        <h2 className="text-xl font-bold mb-2">Bienvenido</h2>
-        <p>Estás en tu refugio y debes sobrevivir.</p>
-        <p>
-          <b>Recoge cartas</b> y decide por tu vida. <b>Explora</b> y <b>recolecta objetos</b>.
-        </p>
-        <p>Investiga notas e historia del juego.</p>
-        <p className="mb-2">
-          <b>El tiempo avanza con cada acción</b>: utiliza bien tu tiempo.
-        </p>
-        <p className="mb-4">
-          <b>Crea tu personaje inicial</b> cambiando el nombre y agregando una bio.
-          <br />
-          <b>Agrega personajes</b> con “+ Agregar”.
-          <br />El juego <b>empieza cuando presionas Play</b> y puedes pausar en cualquier momento.
-        </p>
-        <div className="flex gap-3 justify-end pt-2">
-          <button className="px-4 py-2 rounded bg-neutral-700 hover:bg-neutral-600" onClick={onClose}>
-            Entendido
+    <div className="azrpg-welcome-overlay fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur">
+      <div className="azrpg-welcome-panel relative max-w-[980px] w-full mx-4 rounded-2xl border border-neutral-700 bg-neutral-900/90 p-6 shadow-xl text-neutral-200">
+        <button
+          aria-label="Cerrar"
+          onClick={close}
+          className="azrpg-welcome-close absolute top-3 right-3 text-neutral-400 hover:text-white"
+        >
+          ✕
+        </button>
+
+        <div className="azrpg-welcome-tabs flex gap-6 mb-4 border-b border-neutral-700">
+          <button
+            className={`azrpg-welcome-tab pb-2 ${
+              tab === "how" ? "border-b-2 border-red-500 text-white" : "text-neutral-400"
+            }`}
+            onClick={() => setTab("how")}
+          >
+            Cómo jugar
           </button>
-          <button className="px-4 py-2 rounded bg-red-700 hover:bg-red-600 text-white" onClick={onStart}>
-            Iniciar juego
+          <button
+            className={`azrpg-welcome-tab pb-2 ${
+              tab === "story" ? "border-b-2 border-red-500 text-white" : "text-neutral-400"
+            }`}
+            onClick={() => setTab("story")}
+          >
+            Historia
+          </button>
+        </div>
+
+        <div className="azrpg-welcome-content max-h-[60vh] overflow-y-auto space-y-3">
+          {tab === "how" ? (
+            <div className="azrpg-welcome-how space-y-3">
+              <p>
+                <b>Fases del día:</b> amanecer, día, atardecer y noche. Cada acción consume tiempo.
+              </p>
+              <p>
+                <b>Recursos:</b> comida, agua, medicina, combustible, munición y materiales aseguran la supervivencia.
+              </p>
+              <p>
+                <b>Campamento:</b> protege la defensa y comodidad para resistir.
+              </p>
+              <p>
+                <b>Equipo:</b> administra inventario y armas de tu grupo.
+              </p>
+              <p>
+                <b>Cartas de decisión:</b> elige con cuidado; afectan moral, amenaza y recursos.
+              </p>
+              <p>
+                <b>Combate:</b> enfrenta a los infectados usando habilidades y estrategia.
+              </p>
+              <p>
+                <b>Exploración:</b> arriesga para hallar recursos y pistas.
+              </p>
+              <p>
+                <b>Victoria:</b> la comunidad sobrevive varios días. <b>Derrota:</b> la amenaza o la moral llegan a cero.
+              </p>
+              <p className="text-sm text-neutral-400">
+                Consejo: planifica cada paso; el tiempo es tu recurso más valioso.
+              </p>
+            </div>
+          ) : (
+            <div className="azrpg-welcome-story space-y-3">
+              <p>Año 2130. Neo Santiago es un laberinto de ruinas y neón.</p>
+              <p>Una infección arrasó con la mayoría, dejando hordas de no muertos.</p>
+              <p>Los últimos humanos resisten en enclaves fortificados, cada día más aislados.</p>
+              <p>La amenaza crece con cada noche. Tu misión: mantener viva a tu comunidad.</p>
+            </div>
+          )}
+        </div>
+
+        <div className="azrpg-welcome-actions mt-6 flex justify-end gap-3">
+          <button
+            onClick={dismiss}
+            className="azrpg-welcome-dismiss px-4 py-2 rounded bg-neutral-700 hover:bg-neutral-600"
+          >
+            No volver a mostrar
+          </button>
+          <button
+            onClick={close}
+            className="azrpg-welcome-start px-4 py-2 rounded bg-red-700 hover:bg-red-600 text-white"
+          >
+            Comenzar
           </button>
         </div>
       </div>
     </div>
-  )
+  );
 }
+


### PR DESCRIPTION
## Summary
- add full-screen WelcomeOverlay with tabs for "Cómo jugar" and "Historia"
- persist dismissal in localStorage and close via buttons or ESC
- integrate overlay into App

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b87114106c8325a15ae510fd1954fd