### PR TITLE
feat: add status system, weapon data and UI scaffolding

### DIFF
--- a/src/components/TurnToast.tsx
+++ b/src/components/TurnToast.tsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from "react";
+
+export type TurnToastData = { title: string; subtitle?: string };
+
+export default function TurnToast({ data, onClose, autoMs=2200 }:{
+  data: TurnToastData | null; onClose: ()=>void; autoMs?: number;
+}){
+  const [show, setShow] = useState(false);
+  useEffect(()=>{
+    if(!data) return;
+    setShow(true);
+    const t = setTimeout(()=> setShow(false), autoMs);
+    const t2 = setTimeout(()=> onClose(), autoMs+200);
+    return ()=>{ clearTimeout(t); clearTimeout(t2); };
+  }, [data]);
+  if(!data) return null;
+  return (
+    <div className={`fixed top-6 left-1/2 -translate-x-1/2 z-[9998] pointer-events-none transition-opacity duration-200 ${show?"opacity-100":"opacity-0"}`}>
+      <div className="pointer-events-auto px-4 py-3 rounded-xl border border-neutral-700 bg-neutral-950/95 shadow-lg text-center">
+        <div className="font-semibold">{data.title}</div>
+        {data.subtitle && <div className="text-sm text-neutral-400">{data.subtitle}</div>}
+        <button className="mt-2 text-xs underline text-neutral-300 hover:text-white" onClick={onClose}>Cerrar</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WeaponSelector.tsx
+++ b/src/components/WeaponSelector.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Weapon } from "../data/weapons";
+
+export default function WeaponSelector({
+  weapons, value, onChange, disabled
+}: { weapons: Weapon[]; value?: string; onChange:(id:string)=>void; disabled?: boolean }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {weapons.map(w => (
+        <button
+          key={w.id}
+          disabled={disabled}
+          onClick={()=>onChange(w.id)}
+          className={`px-3 py-1 rounded-lg border text-sm ${value===w.id ? "border-emerald-500 bg-emerald-500/10" : "border-neutral-700 hover:bg-neutral-800/60"}`}
+          title={`${w.name} • +${w.hitBonus} golpe • ${w.damage.times}d${w.damage.faces}${w.damage.mod>=0?`+${w.damage.mod}`:w.damage.mod}`}
+        >
+          {w.name}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/data/weapons.ts
+++ b/src/data/weapons.ts
@@ -1,0 +1,47 @@
+export type Weapon = {
+  id: string;
+  name: string;
+  type: 'melee'|'ranged';
+  hitBonus: number;
+  damage: { times: number; faces: number; mod: number };
+  usesAttr: 'Fuerza'|'Destreza';
+  ammoCost?: number;
+};
+
+export const WEAPONS: Weapon[] = [
+  { id:'fists',  name:'Puños',             type:'melee',  hitBonus:0, damage:{times:1,faces:4,mod:0},  usesAttr:'Fuerza' },
+  { id:'knife',  name:'Navaja',            type:'melee',  hitBonus:1, damage:{times:1,faces:6,mod:0},  usesAttr:'Fuerza' },
+  { id:'kukri',  name:'Cuchillo',          type:'melee',  hitBonus:2, damage:{times:1,faces:6,mod:1},  usesAttr:'Fuerza' },
+  { id:'tacdag', name:'Daga Táctica',      type:'melee',  hitBonus:2, damage:{times:1,faces:6,mod:2},  usesAttr:'Fuerza' },
+  { id:'pipe',   name:'Tubo de metal',     type:'melee',  hitBonus:0, damage:{times:1,faces:8,mod:0},  usesAttr:'Fuerza' },
+  { id:'bat',    name:'Bate de madera',    type:'melee',  hitBonus:1, damage:{times:1,faces:6,mod:1},  usesAttr:'Fuerza' },
+  { id:'nailbat',name:'Bate con clavos',   type:'melee',  hitBonus:1, damage:{times:1,faces:8,mod:0},  usesAttr:'Fuerza' },
+  { id:'machete',name:'Machete',           type:'melee',  hitBonus:1, damage:{times:1,faces:8,mod:1},  usesAttr:'Fuerza' },
+  { id:'axe',    name:'Hacha',             type:'melee',  hitBonus:0, damage:{times:1,faces:10,mod:0}, usesAttr:'Fuerza' },
+  { id:'hammer', name:'Martillo',          type:'melee',  hitBonus:1, damage:{times:1,faces:6,mod:2},  usesAttr:'Fuerza' },
+  { id:'wrench', name:'Llave inglesa',     type:'melee',  hitBonus:1, damage:{times:1,faces:6,mod:1},  usesAttr:'Fuerza' },
+  { id:'crowbar',name:'Barra palanca',     type:'melee',  hitBonus:1, damage:{times:1,faces:8,mod:1},  usesAttr:'Fuerza' },
+  { id:'katana', name:'Katana',            type:'melee',  hitBonus:3, damage:{times:1,faces:10,mod:1}, usesAttr:'Fuerza' },
+  { id:'spear',  name:'Lanza improvisada', type:'melee',  hitBonus:1, damage:{times:1,faces:8,mod:0},  usesAttr:'Fuerza' },
+  { id:'pick',   name:'Pico',              type:'melee',  hitBonus:0, damage:{times:1,faces:8,mod:2},  usesAttr:'Fuerza' },
+  { id:'mace',   name:'Maza casera',       type:'melee',  hitBonus:0, damage:{times:1,faces:10,mod:1}, usesAttr:'Fuerza' },
+  { id:'saw',    name:'Sierra manual',     type:'melee',  hitBonus:0, damage:{times:2,faces:4,mod:1},  usesAttr:'Fuerza' },
+  { id:'sdriver',name:'Destornillador grande',type:'melee',hitBonus:1,damage:{times:1,faces:6,mod:0},  usesAttr:'Fuerza' },
+  { id:'chain',  name:'Cadena',            type:'melee',  hitBonus:0, damage:{times:1,faces:6,mod:1},  usesAttr:'Fuerza' },
+  { id:'club',   name:'Garrote',           type:'melee',  hitBonus:1, damage:{times:1,faces:6,mod:0},  usesAttr:'Fuerza' },
+  { id:'bottle', name:'Botella rota',      type:'melee',  hitBonus:1, damage:{times:1,faces:4,mod:2},  usesAttr:'Fuerza' },
+  { id:'shovel', name:'Pala',              type:'melee',  hitBonus:0, damage:{times:1,faces:8,mod:1},  usesAttr:'Fuerza' },
+  { id:'pipehd', name:'Cañería pesada',    type:'melee',  hitBonus:0, damage:{times:1,faces:10,mod:1}, usesAttr:'Fuerza' },
+  { id:'faxe',   name:'Hacha de bombero',  type:'melee',  hitBonus:0, damage:{times:1,faces:12,mod:0}, usesAttr:'Fuerza' },
+
+  { id:'sling',  name:'Hondita',           type:'ranged', hitBonus:1, damage:{times:1,faces:4,mod:1},  usesAttr:'Destreza', ammoCost:0 },
+  { id:'xbow',   name:'Ballesta',          type:'ranged', hitBonus:3, damage:{times:1,faces:8,mod:2},  usesAttr:'Destreza', ammoCost:1 },
+  { id:'pistol', name:'Pistola',           type:'ranged', hitBonus:4, damage:{times:1,faces:6,mod:4},  usesAttr:'Destreza', ammoCost:1 },
+  { id:'rifle',  name:'Rifle',             type:'ranged', hitBonus:5, damage:{times:1,faces:8,mod:4},  usesAttr:'Destreza', ammoCost:1 },
+  { id:'shotgun',name:'Escopeta',          type:'ranged', hitBonus:3, damage:{times:2,faces:4,mod:3},  usesAttr:'Destreza', ammoCost:1 },
+  { id:'smg',    name:'Subfusil (SMG)',    type:'ranged', hitBonus:5, damage:{times:1,faces:6,mod:3},  usesAttr:'Destreza', ammoCost:1 },
+];
+
+export function findWeaponById(id?: string) {
+  return WEAPONS.find(w => w.id === id);
+}

--- a/src/systems/status.ts
+++ b/src/systems/status.ts
@@ -1,0 +1,80 @@
+export type ConditionId = 'bleeding'|'infected'|'stunned';
+
+export type ConditionInfo = {
+  id: ConditionId;
+  turnsLeft?: number;
+  intensity?: number;
+  persistent?: boolean;
+};
+
+export type Conditions = Partial<Record<ConditionId, ConditionInfo>>;
+
+export function hasCondition(conds: Conditions|undefined, id: ConditionId){
+  return !!conds && !!conds[id];
+}
+
+export function addCondition(conds: Conditions|undefined, c: ConditionInfo): Conditions {
+  return { ...(conds ?? {}), [c.id]: c };
+}
+
+export function removeCondition(conds: Conditions|undefined, id: ConditionId): Conditions {
+  if(!conds) return {};
+  const nc = { ...conds }; delete nc[id];
+  return nc;
+}
+
+export function applyStartOfTurnConditions(
+  actor: { name: string; maxHp: number; hp: number; conditions?: Conditions },
+  log: (s:string)=>void
+): { skipAction: boolean; newConditions: Conditions } {
+  let skipAction = false;
+  let newConds: Conditions = { ...(actor.conditions ?? {}) };
+
+  const st = newConds.stunned;
+  if (st) {
+    if (Math.random() < 0.25) {
+      log(`😵 ${actor.name} está aturdido y no logra actuar este turno.`);
+      skipAction = true;
+    }
+    if (typeof st.turnsLeft === 'number') {
+      const tl = Math.max(0, st.turnsLeft - 1);
+      if (tl === 0) newConds = removeCondition(newConds, 'stunned');
+      else newConds = addCondition(newConds, { ...st, turnsLeft: tl });
+    }
+  }
+
+  return { skipAction, newConditions: newConds };
+}
+
+export function applyEndOfTurnConditions(
+  actor: { name: string; maxHp: number; hp: number; conditions?: Conditions },
+  log: (s:string)=>void
+): { hpDelta: number; newConditions: Conditions } {
+  let hpDelta = 0;
+  let newConds: Conditions = { ...(actor.conditions ?? {}) };
+
+  const bleed = newConds.bleeding;
+  if (bleed) {
+    const dmg = Math.max(1, Math.floor(actor.maxHp / 16));
+    hpDelta -= dmg;
+    log(`🩸 ${actor.name} sangra (-${dmg} PV).`);
+    if (typeof bleed.turnsLeft === 'number') {
+      const tl = Math.max(0, bleed.turnsLeft - 1);
+      if (tl === 0) newConds = removeCondition(newConds, 'bleeding');
+      else newConds = addCondition(newConds, { ...bleed, turnsLeft: tl });
+    }
+  }
+
+  const inf = newConds.infected;
+  if (inf) {
+    const dmg = Math.max(1, Math.floor(actor.maxHp / 8));
+    hpDelta -= dmg;
+    log(`🧪 La infección avanza en ${actor.name} (-${dmg} PV).`);
+  }
+
+  return { hpDelta, newConditions: newConds };
+}
+
+export function cureCondition(conds: Conditions|undefined, id: ConditionId): Conditions {
+  return removeCondition(conds, id);
+}


### PR DESCRIPTION
## Summary
- add status system utilities for bleeding, infection, and stun effects
- define ~30 weapons with stats and lookup helper
- provide weapon selector and turn toast components for future integration

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8d2b3e22c83258895ddc133e67ee8