### PR TITLE
Add end-of-day summary and day-one decision deck

### DIFF
--- a/src/components/overlays/DayEndSummary.tsx
+++ b/src/components/overlays/DayEndSummary.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+
+export default function DayEndSummary({
+  day, stats, reason, onNext,
+}: {
+  day: number;
+  stats: {
+    enemiesKilled: number; damageDealt: number; damageTaken: number;
+    healsUsed: number; shotsFired: number; misses: number; escapes: number;
+    decisionsTaken: number; exploresDone: number; itemsFound: number; timeSpentMs: number;
+  };
+  reason: "time_out" | "decks_exhausted" | "turns_exhausted" | "manual";
+  onNext: () => void;
+}) {
+  const mins = Math.floor(stats.timeSpentMs / 60000);
+  const secs = Math.floor((stats.timeSpentMs % 60000) / 1000);
+  return (
+    <div className="fixed inset-0 z-[9999] bg-black/60 backdrop-blur-md flex items-center justify-center">
+      <div className="w-[min(820px,92vw)] rounded-2xl border border-neutral-800 bg-neutral-950/95 shadow-2xl p-6">
+        <h2 className="text-2xl font-bold mb-2">Día {day} terminado</h2>
+        <p className="text-sm text-neutral-400 mb-4">
+          Motivo: {reason === "time_out" ? "Fin del tiempo" :
+                    reason === "decks_exhausted" ? "Mazos agotados" :
+                    reason === "turns_exhausted" ? "Acciones agotadas" : "Continuación"}
+        </p>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800">🧟 Abatidos: <b>{stats.enemiesKilled}</b></div>
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800">⚔️ Daño infligido: <b>{stats.damageDealt}</b></div>
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800">🩸 Daño recibido: <b>{stats.damageTaken}</b></div>
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800">💊 Curas: <b>{stats.healsUsed}</b></div>
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800">🔫 Disparos: <b>{stats.shotsFired}</b> / ❌ Fallos: <b>{stats.misses}</b></div>
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800">🏃‍♂️ Huidas: <b>{stats.escapes}</b></div>
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800">📖 Decisiones: <b>{stats.decisionsTaken}</b></div>
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800">🔎 Exploraciones: <b>{stats.exploresDone}</b></div>
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800">🧰 Objetos hallados: <b>{stats.itemsFound}</b></div>
+          <div className="p-3 rounded-lg bg-neutral-900 border border-neutral-800 col-span-2">⏱️ Tiempo consumido: <b>{mins}m {secs}s</b></div>
+        </div>
+
+        <div className="mt-6 flex justify-end">
+          <button
+            className="px-5 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-500 font-semibold shadow"
+            onClick={onNext}
+          >
+            Pasar al siguiente día
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/data/days/day1/decisionCards.day1.ts
+++ b/src/data/days/day1/decisionCards.day1.ts
@@ -1,501 +1,635 @@
-// src/data/days/day1/decisionCards.day1.ts
-import type { DecisionCard } from "@/data/decisionCards";
+import { DecisionCard } from "../../decisionCards";
 
 export const day1DecisionCards: DecisionCard[] = [
   {
     id: 201,
-    title: "La guardería silenciosa",
-    text:
-      "Un colegio abandonado conserva una guardería casi intacta. Juguetes apilados, cunas vacías y dibujos en las paredes. En la despensa hay latas caducadas pero quizá aprovechables. Dos puertas internas están atrancadas desde fuera: de un lado se oyen golpes apagados; del otro, nada. El grupo duda entre registrar todo o salir sin tocar nada.",
+    title: "Luces en el almacén municipal",
+    text: `Al caer la tarde, a lo lejos parpadean luces dentro del almacén municipal.
+El grupo discute si se trata de supervivientes o una trampa.
+Se oyen golpes metálicos, como si alguien buscara en contenedores.
+Entrar ahora implicaría gastar energía y quizá munición.
+Pero si esperamos, alguien más podría vaciarlo antes que nosotros.`,
     choices: [
-      { text: "Forzar ambas puertas", effect: { zombies: 2, materials: 3, morale: -2 } },
-      { text: "Solo registrar la despensa", effect: { food: 4, water: 2, morale: 1 } },
-      { text: "Retirarse en silencio", effect: { morale: -3, karma: 2 } }
-    ]
+      { text: "Entrar en formación y registrar", effect: { materials: 4, ammo: -2, threat: 2, advanceMs: 150000 } },
+      { text: "Esperar y observar desde lejos", effect: { morale: -1, advanceMs: 120000 } },
+      { text: "Marcar el lugar y retirarse", effect: { morale: 1, karma: 1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 202,
-    title: "Cartas sin destinatario",
-    text:
-      "Encuentras un saco de cartas nunca enviadas con nombres y direcciones de la ciudad. Algunas prometen medicamentos, otras despedidas urgentes. Podrías seguir una dirección cercana, pero el mapa muestra zonas con actividad de hordas.",
+    title: "Rastro de humo en la autopista",
+    text: `Un hilo de humo negro se eleva tras los coches volcados de la autopista.
+Podría tratarse de una fogata improvisada por otros supervivientes.
+También podría ser una señal para atraer curiosos y emboscarlos.
+La zona abierta expone al grupo a los francotiradores y a las hordas.
+Decidir acercarse o evitar el área consume un tiempo precioso.`,
     choices: [
-      { text: "Seguir la dirección más cercana", effect: { medicine: 2, zombies: 1, morale: 2 } },
-      { text: "Clasificar y dejar pistas para otros", effect: { morale: 3, karma: 4 } },
-      { text: "Quemarlas para hacer una señal", effect: { morale: -4, fuel: 2 } }
-    ]
+      { text: "Avanzar investigando con cautela", effect: { threat: 2, fuel: -1, advanceMs: 120000 } },
+      { text: "Rodear por el viejo túnel", effect: { fuel: -2, morale: 1, advanceMs: 180000 } },
+      { text: "Ignorar el humo y seguir", effect: { morale: -1, karma: 1, advanceMs: 90000 } },
+    ],
   },
   {
     id: 203,
-    title: "El puente oxidado",
-    text:
-      "Un puente metálico cruje sobre un río oscuro. Del otro lado, una farmacia intacta. La estructura resiste si cruzáis de uno en uno, pero el ruido atraería a los infectados de la ribera.",
+    title: "Ofertas de un mercader solitario",
+    text: `Un hombre armado con chaleco improvisado ofrece trueques desde una furgoneta.
+Tiene cajas con medicinas, munición y herramientas envueltas en tela.
+Dice que la carretera será cerrada por una horda en pocas horas.
+Sus ojos nerviosos no inspiran demasiada confianza al grupo.
+Negociar con él podría ahorrarnos días o costarnos la vida.`,
     choices: [
-      { text: "Cruzar ahora, rápido", effect: { medicine: 3, zombies: 2, morale: -1 } },
-      { text: "Refuerzos improvisados antes de cruzar", effect: { materials: -3, morale: 2 } },
-      { text: "Buscar un vado río abajo", effect: { karma: 1, morale: -1 } }
-    ]
+      { text: "Comprar medicinas con munición", effect: { medicine: 3, ammo: -5, morale: 2, advanceMs: 60000 } },
+      { text: "Intercambiar trabajo por recursos", effect: { food: 2, water: 2, morale: 1, advanceMs: 120000 } },
+      { text: "Rechazar la oferta y alejarse", effect: { threat: -1, karma: 1, advanceMs: 30000 } },
+    ],
   },
   {
     id: 204,
-    title: "El huerto en la azotea",
-    text:
-      "En una azotea hay un pequeño huerto cuidado por un anciano desconfiado. Pide agua a cambio de verduras para varios días. Desconfía de los recién llegados y mira de reojo vuestras armas.",
+    title: "Puente de cuerdas sobre el río",
+    text: `Un viejo puente de cuerdas balancea sobre el agua turbia y ruidosa.
+Del otro lado hay un edificio que parece intacto y sin saquear.
+La estructura cruje con cada ráfaga de viento que atraviesa el cañón.
+Cruzarlo con todo el equipo podría terminar en una caída mortal.
+Buscar otra ruta implica retroceder varios kilómetros y perder tiempo.`,
     choices: [
-      { text: "Intercambiar agua por comida", effect: { water: -3, food: 6, morale: 2 } },
-      { text: "Intentar robar de noche", effect: { food: 4, morale: -5, karma: -6 } },
-      { text: "Ayudar a reforzar su puerta", effect: { materials: -2, food: 3, karma: 5 } }
-    ]
+      { text: "Cruzarlo de uno en uno", effect: { materials: 1, threat: 1, advanceMs: 90000 } },
+      { text: "Reforzarlo con cuerdas extra", effect: { materials: -3, advanceMs: 150000 } },
+      { text: "Dar media vuelta y rodear", effect: { fuel: -1, morale: -1, advanceMs: 210000 } },
+    ],
   },
   {
     id: 205,
-    title: "El camión frigorífico",
-    text:
-      "Un camión frigorífico bloquea una calle. Dentro, contenedores sellados. El generador aún tiene combustible, pero su ruido puede atraer una horda. Romper los sellos podría liberar un olor insoportable.",
+    title: "Refugio con normas estrictas",
+    text: `Una comunidad fortificada permite el acceso solo con reglas claras.
+Piden entregar munición y prometer silencio total durante la noche.
+Algunos miembros del grupo desconfían de los ojos vigilantes en la muralla.
+El refugio promete comida caliente y literas limpias para descansar.
+Aceptar o rechazar la invitación podría dividir al grupo.`,
     choices: [
-      { text: "Abrir contenedores", effect: { food: 5, fuel: -2, zombies: 2 } },
-      { text: "Llevarse el generador", effect: { fuel: 4, materials: 2, morale: 1 } },
-      { text: "Sellarlo y dejar advertencias", effect: { karma: 3, morale: 2 } }
-    ]
+      { text: "Aceptar y entregar munición", effect: { ammo: -5, morale: 2, advanceMs: 120000 } },
+      { text: "Negociar otra forma de pago", effect: { materials: -3, morale: 1, karma: 2, advanceMs: 180000 } },
+      { text: "Rechazar y seguir viaje", effect: { morale: -2, advanceMs: 60000 } },
+    ],
   },
   {
     id: 206,
-    title: "El refugio con normas",
-    text:
-      "Un grupo organizado ofrece hospedaje por dos noches a cambio de munición y obedecer sus reglas estrictas: silencio total al anochecer y sin preguntas. Alguien de tu grupo no confía en ellos.",
+    title: "Camión frigorífico abandonado",
+    text: `Un camión frigorífico bloquea la calle con su puerta trasera cerrada.
+El generador aún zumba y desprende vapor blanco por un tubo roto.
+Dentro podrían quedar carnes congeladas o algo mucho peor.
+El olor dulce que se filtra despierta el apetito y la sospecha.
+Abrirlo podría atraer a toda criatura hambrienta de la zona.`,
     choices: [
-      { text: "Aceptar las condiciones", effect: { ammo: -5, morale: 3 } },
-      { text: "Negociar otra forma de pago", effect: { materials: -4, morale: 1, karma: 2 } },
-      { text: "Rechazar y seguir", effect: { morale: -2 } }
-    ]
+      { text: "Forzar la puerta y registrar", effect: { food: 5, zombies: 2, fuel: -1, advanceMs: 120000 } },
+      { text: "Apagar el generador y sellar", effect: { fuel: 2, morale: 1, advanceMs: 60000 } },
+      { text: "Ignorarlo y avanzar", effect: { threat: -1, advanceMs: 30000 } },
+    ],
   },
   {
     id: 207,
-    title: "Llamadas en el hospital",
-    text:
-      "En una sala de urgencias, varios teléfonos aún reciben llamadas automáticas de familiares. Hay un quirófano cerrado con llave y un triaje con cajas de guantes y gasas.",
+    title: "Niños perdidos en el parque",
+    text: `Entre los columpios oxidados se escuchan risas apagadas y pasos ligeros.
+Dos figuras pequeñas corren entre los arbustos llevando mochilas ajenas.
+Podrían ser niños que sobrevivieron solos o un señuelo para asaltantes.
+El parque abierto deja al grupo expuesto desde todos los ángulos.
+Decidir ayudarlos o dejarlos puede marcar nuestra moral para siempre.`,
     choices: [
-      { text: "Forzar el quirófano", effect: { medicine: 4, zombies: 2, morale: -1 } },
-      { text: "Recolectar suministros básicos", effect: { medicine: 2, materials: 1, morale: 1 } },
-      { text: "Registrar y dejar un mapa para otros", effect: { karma: 3, morale: 2 } }
-    ]
+      { text: "Llamar y ofrecer comida", effect: { food: -2, morale: 3, karma: 3, advanceMs: 90000 } },
+      { text: "Perseguirlos con armas", effect: { threat: 2, ammo: -1, morale: -2, advanceMs: 60000 } },
+      { text: "Retirarse sin intervenir", effect: { morale: -1, advanceMs: 30000 } },
+    ],
   },
   {
     id: 208,
-    title: "El semáforo parpadeante",
-    text:
-      "Un cruce principal sigue recibiendo energía. Las luces parpadeantes parecen atraer infectados. Unos coches abandonados aíslan una pequeña tienda de ultramarinos con la reja a medio cerrar.",
+    title: "Gasolinera cubierta de grafitis",
+    text: `Una gasolinera en ruinas muestra grafitis que advierten de peligro inminente.
+La tienda anexa tiene la persiana medio rota y huellas recientes de botas.
+El surtidor parece intacto pero la alarma podría seguir conectada.
+Quedarse demasiado tiempo aquí puede llamar a merodeadores o zombis.
+Sin combustible no llegaremos a la ciudad antes de anochecer.`,
     choices: [
-      { text: "Apagar el cuadro eléctrico", effect: { materials: 2, zombies: -1, morale: 1 } },
-      { text: "Aprovechar la distracción para saquear", effect: { food: 4, water: 2, zombies: 1 } },
-      { text: "Sellar el cruce con barricadas", effect: { materials: -5, karma: 3 } }
-    ]
+      { text: "Sifonear combustible rápido", effect: { fuel: 3, threat: 2, advanceMs: 90000 } },
+      { text: "Buscar comida dentro de la tienda", effect: { food: 2, water: 1, zombies: 1, advanceMs: 120000 } },
+      { text: "Dejar una marca y seguir", effect: { karma: 1, morale: -1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 209,
-    title: "Cuna mecánica",
-    text:
-      "En un taller de bicicletas hay piezas suficientes para armar carritos de carga. El dueño dejó una nota pidiendo que no toquen su caja fuerte 'por respeto a los caídos'.",
+    title: "Campamento improvisado bajo el puente",
+    text: `Debajo del puente se acumulan mantas viejas, latas y un fuego apagado.
+Alguien estuvo aquí hasta hace poco, quizá aún siga cerca observando.
+Los pilares del puente ofrecen cierta cobertura pero limitan la vista.
+Examinar los restos puede revelar pistas de otros grupos errantes.
+No detenerse significa perder posibles suministros escondidos.`,
     choices: [
-      { text: "Tomar solo piezas visibles", effect: { materials: 4, morale: 2 } },
-      { text: "Forzar la caja fuerte", effect: { ammo: 6, morale: -4, karma: -6 } },
-      { text: "Montar un carrito y dejar herramientas", effect: { materials: -2, morale: 3, karma: 4 } }
-    ]
+      { text: "Registrar entre las mantas", effect: { materials: 2, food: 1, advanceMs: 60000 } },
+      { text: "Esperar al dueño para hablar", effect: { morale: 1, threat: 1, advanceMs: 150000 } },
+      { text: "Continuar la marcha sin mirar", effect: { morale: -1, advanceMs: 30000 } },
+    ],
   },
   {
     id: 210,
-    title: "La llamada al norte",
-    text:
-      "Una radio improvisada emite un mensaje: 'Ruta segura al norte, alimentos y agua, vengan armados'. La señal sube y baja. Podría ser una trampa o una oportunidad real.",
+    title: "Patrulla militar caída",
+    text: `Un vehículo militar volcado bloquea parte de la avenida principal.
+Los cuerpos con uniformes indican que la patrulla fue atacada por sorpresa.
+Las cajas de suministros están cerradas con cadenas resistentes.
+Tal vez haya un mapa o un transmisor útil entre los restos.
+Manipular el vehículo podría atraer atención desde las azoteas cercanas.`,
     choices: [
-      { text: "Responder y ofrecer intercambio", effect: { karma: 2, morale: 2 } },
-      { text: "Marcar la ruta y partir", effect: { fuel: -3, zombies: 1, morale: 1 } },
-      { text: "Ignorar y registrar edificios cercanos", effect: { food: 2, water: 2 } }
-    ]
+      { text: "Forzar cajas de suministros", effect: { ammo: 6, medicine: 2, zombies: 1, advanceMs: 120000 } },
+      { text: "Buscar documentos rápidos", effect: { materials: 1, morale: 1, advanceMs: 60000 } },
+      { text: "Desviar el camino sin tocar nada", effect: { threat: -1, advanceMs: 30000 } },
+    ],
   },
   {
     id: 211,
-    title: "Cartel: 'No entrar'",
-    text:
-      "Una casa tapiada con un cartel escrito a mano: 'No entrar. Contagio'. Por la ventana se ve una mesa con medicamentos y una foto de familia.",
+    title: "Cultivo clandestino en azotea",
+    text: `Subiendo a un edificio encontramos una azotea con plantas en macetas.
+Un joven delgado vigila con un rifle y pide trueque por verduras frescas.
+Dice que los vecinos quieren echarlo para quedarse con la producción.
+El lugar tiene agua recolectada y un pequeño gallinero improvisado.
+Negociar, robar o marcharnos define nuestra reputación en la zona.`,
     choices: [
-      { text: "Entrar con precaución", effect: { medicine: 3, zombies: 1, morale: -1 } },
-      { text: "Respetar el cartel y dejar agua", effect: { water: -2, karma: 4, morale: 2 } },
-      { text: "Marcar la casa en el mapa", effect: { karma: 1 } }
-    ]
+      { text: "Trueque justo por verduras", effect: { food: 4, water: -2, morale: 1, advanceMs: 90000 } },
+      { text: "Amenazar y tomar todo", effect: { food: 6, morale: -4, karma: -5, zombies: 1, advanceMs: 60000 } },
+      { text: "Desearle suerte y partir", effect: { karma: 2, advanceMs: 30000 } },
+    ],
   },
   {
     id: 212,
-    title: "La autopista del silencio",
-    text:
-      "Una autopista vacía lleva a un túnel. En la entrada, huellas recientes y rastros de arrastre. Se oye un eco rítmico en la oscuridad, como metal contra piedra.",
+    title: "Museo convertido en guarida",
+    text: `Las puertas de cristal del museo están cubiertas con tablones viejos.
+Dentro se oyen pasos apresurados y murmullos tras las vitrinas oscuras.
+Quizá refugiados ocupen las salas usando las obras como barricadas.
+El sótano podría esconder generadores y depósitos de agua limpia.
+Entrar por la fuerza podría destruir patrimonio y encender hostilidad.`,
     choices: [
-      { text: "Atravesar el túnel", effect: { fuel: -2, zombies: 2, morale: -2 } },
-      { text: "Dar un rodeo por la colina", effect: { fuel: -4, morale: 1 } },
-      { text: "Montar un puesto de observación", effect: { materials: -2, morale: 2 } }
-    ]
+      { text: "Entrar negociando", effect: { water: 2, morale: 2, advanceMs: 90000 } },
+      { text: "Buscar una entrada trasera", effect: { materials: -2, threat: 1, advanceMs: 120000 } },
+      { text: "Evitar el museo", effect: { morale: -1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 213,
-    title: "Biblioteca con candado",
-    text:
-      "La biblioteca del barrio está cerrada, pero en el patio se ven cajas con manuales técnicos, guías de primeros auxilios y mapas. Alguien dejó notas sobre rutas seguras.",
+    title: "Rituales en la iglesia abandonada",
+    text: `La vieja iglesia tiene velas encendidas y símbolos pintados con sangre.
+Un grupo de fieles susurra plegarias alrededor del altar principal.
+Al vernos, el líder pide comida a cambio de bendiciones y protección.
+Algunos miembros parecen enfermos y se balancean al ritmo de la oración.
+Aceptar el trato puede unirnos o atraer a fanáticos peligrosos.`,
     choices: [
-      { text: "Forzar acceso y llevar manuales", effect: { materials: 1, morale: 3, philosophical_strength: true } },
-      { text: "Copiar mapas y dejar todo igual", effect: { morale: 2, karma: 3 } },
-      { text: "Publicar un tablón con rutas", effect: { karma: 4, morale: 1 } }
-    ]
+      { text: "Compartir comida y quedarse", effect: { food: -3, morale: 2, karma: 2, advanceMs: 150000 } },
+      { text: "Registrarlo todo en secreto", effect: { medicine: 1, materials: 1, morale: -2, advanceMs: 90000 } },
+      { text: "Irse antes de llamar la atención", effect: { threat: -1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 214,
-    title: "El perro del callejón",
-    text:
-      "Un perro hambriento te sigue varias cuadras. Buen olfato, asustado por ruidos fuertes. Un miembro del grupo quiere adoptarlo; otro teme que delate posiciones.",
+    title: "Silo de granos con guardias",
+    text: `Un silo intacto domina el horizonte con su estructura metálica.
+Dos guardias con escopetas vigilan la entrada y exigen contraseñas.
+Rumores dicen que almacenan grano suficiente para un mes de viaje.
+Las escaleras laterales permiten un acceso arriesgado por la parte superior.
+Resolver esto determina si tendremos pan o enemigos mañana.`,
     choices: [
-      { text: "Compartir comida y entrenarlo", effect: { food: -2, morale: 4, karma: 3 } },
-      { text: "Asustarlo para que se vaya", effect: { morale: -3 } },
-      { text: "Que se quede fuera del campamento", effect: { morale: 1 } }
-    ]
+      { text: "Pagar con combustible", effect: { fuel: -3, food: 5, morale: 1, advanceMs: 90000 } },
+      { text: "Escalar durante la noche", effect: { food: 4, threat: 2, zombies: 1, advanceMs: 150000 } },
+      { text: "Abandonar el silo", effect: { morale: -1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 215,
-    title: "Mercado fantasma",
-    text:
-      "Un antiguo mercado municipal aún tiene puestos con cajas cerradas. El techo, a punto de colapsar. Se ven sombras moviéndose entre los pasillos.",
+    title: "Mensaje en la radio pirata",
+    text: `Un transmisor improvisado emite una voz pidiendo auxilio en canal abierto.
+La señal proviene de un barrio plagado de edificios derrumbados.
+Podría ser una trampa para saqueadores o una persona desesperada.
+Nuestro equipo de radio necesita energía extra para triangular la fuente.
+Acudir o no podría marcar la diferencia en nuestra humanidad.`,
     choices: [
-      { text: "Barrido rápido por los pasillos", effect: { food: 3, water: 2, zombies: 1 } },
-      { text: "Entrar por el techo con cuerdas", effect: { materials: -3, food: 5 } },
-      { text: "Sellar accesos y volver luego", effect: { materials: -2, morale: 1 } }
-    ]
+      { text: "Seguir la señal de inmediato", effect: { fuel: -2, threat: 2, morale: 1, advanceMs: 120000 } },
+      { text: "Enviar una respuesta breve", effect: { fuel: -1, karma: 1, advanceMs: 60000 } },
+      { text: "Ignorar la transmisión", effect: { morale: -2, advanceMs: 30000 } },
+    ],
   },
   {
     id: 216,
-    title: "El bus escolar",
-    text:
-      "Un bus escolar encajado en una zanja. Dentro, mochilas con útiles y notas de emergencia. El conductor no está. La puerta trasera está trabada.",
+    title: "Cadáver atado con nota",
+    text: `En medio de la calle hay un cadáver atado con cuerdas y un cartel.
+La nota advierte que cualquiera que robe el barrio será cazado.
+Las casas cercanas tienen puertas reforzadas con láminas metálicas.
+Tal vez sea una táctica de miedo de los residentes aún vivos.
+Decidir si registrar o respetar el aviso afecta a la reputación.`,
     choices: [
-      { text: "Liberar la puerta y registrar", effect: { materials: 2, water: 2, zombies: 1 } },
-      { text: "Solo tomar útiles cercanos", effect: { materials: 1, morale: 1 } },
-      { text: "Remolcar el bus para bloquear un acceso", effect: { fuel: -3, materials: 3, morale: 2 } }
-    ]
+      { text: "Registrar una casa de todos modos", effect: { materials: 3, morale: -3, karma: -2, advanceMs: 90000 } },
+      { text: "Dejar una ofrenda de respeto", effect: { food: -1, morale: 2, karma: 3, advanceMs: 60000 } },
+      { text: "Retirarse sin tocar nada", effect: { threat: -1, advanceMs: 30000 } },
+    ],
   },
   {
     id: 217,
-    title: "La antena rota",
-    text:
-      "Una antena de telecomunicaciones caída podría servir como estructura para trampas perimetrales. Desmontarla llevará horas y hará ruido.",
+    title: "Tienda de mascotas saqueada",
+    text: `Gaviotas y ratas pelean por restos frente a una tienda destrozada.
+Dentro aún hay sacos de alimento y jaulas con agua turbia.
+Un cachorro asustado gime desde un rincón oscuro entre los vidrios.
+Algunos piensan que llevarlo podría animar al campamento.
+Otros creen que solo será una boca más que alimentar.`,
     choices: [
-      { text: "Desmontar para trampas", effect: { materials: 5, zombies: 2, morale: 1 } },
-      { text: "Solo recoger tornillería y cables", effect: { materials: 2, morale: 1 } },
-      { text: "Dejarla como está y avanzar", effect: { morale: -1 } }
-    ]
+      { text: "Rescatar al cachorro", effect: { food: -1, morale: 3, karma: 2, advanceMs: 90000 } },
+      { text: "Tomar pienso para nosotros", effect: { food: 2, water: 1, advanceMs: 60000 } },
+      { text: "Cerrar la puerta y seguir", effect: { morale: -1, advanceMs: 30000 } },
+    ],
   },
   {
     id: 218,
-    title: "Señal en la colina",
-    text:
-      "Desde una colina se ve humo en la distancia. Podría indicar un campamento o un incendio. Una exploración cuidadosa tomaría medio día.",
+    title: "Carretera con barricada civil",
+    text: `Una barricada con coches y muebles impide el paso en la carretera.
+Un cartel pintado dice que la entrada está restringida a conocidos.
+Oímos voces detrás de la defensa discutiendo sobre abrir fuego.
+El desvío más cercano nos retrasaría varias horas de viaje.
+Romper la barricada podría enfrentarnos a civiles asustados.`,
     choices: [
-      { text: "Investigar con sigilo", effect: { fuel: -2, morale: 1, zombies: 1 } },
-      { text: "Enviar un par con radio", effect: { ammo: -2, survivors: 1, morale: 2 } },
-      { text: "Ignorar la señal", effect: { morale: -2 } }
-    ]
+      { text: "Intentar negociar el paso", effect: { morale: 1, threat: 1, advanceMs: 90000 } },
+      { text: "Forzar la barricada", effect: { materials: -2, ammo: -3, morale: -2, advanceMs: 60000 } },
+      { text: "Tomar el desvío largo", effect: { fuel: -3, advanceMs: 180000 } },
+    ],
   },
   {
     id: 219,
-    title: "La tienda de música",
-    text:
-      "Guitarras, tambores y un piano desafinado. El sonido podría atraer problemas o levantar la moral. Entre cajas hay cuerdas, cueros y una linterna.",
+    title: "Viejo cine con proyector activo",
+    text: `Las luces de un proyector parpadean dentro de un cine en ruinas.
+Películas sin sonido se proyectan sobre una pantalla rasgada y sucia.
+Podría haber gente usando la luz para atraer o distraer a alguien.
+El olor a palomitas rancias aún flota entre las butacas rotas.
+Revisar las cabinas podría darnos piezas electrónicas útiles.`,
     choices: [
-      { text: "Tocar una canción breve", effect: { morale: 6, zombies: 1 } },
-      { text: "Tomar útiles y salir", effect: { materials: 2, morale: 1 } },
-      { text: "Dejar un mensaje grabado", effect: { karma: 2, morale: 2 } }
-    ]
+      { text: "Buscar piezas del proyector", effect: { materials: 2, fuel: 1, advanceMs: 90000 } },
+      { text: "Ver la película unos minutos", effect: { morale: 2, threat: 1, advanceMs: 120000 } },
+      { text: "Apagar todo y salir", effect: { threat: -2, advanceMs: 60000 } },
+    ],
   },
   {
     id: 220,
-    title: "Fábrica en silencio",
-    text:
-      "Una fábrica de conservas. En las oficinas, llaves y tarjetas magnéticas. El depósito principal huele a moho. Un zumbido indica generadores auxiliares.",
+    title: "Escombros con voces atrapadas",
+    text: `Entre los escombros de un edificio derrumbado se escuchan gemidos.
+Tal vez haya alguien vivo bajo las placas de hormigón y hierro.
+Mover piedras requiere tiempo y herramientas que apenas tenemos.
+Ignorar los sonidos podría condenar a una persona a morir lentamente.
+El grupo debate si arriesgarse o priorizar su propia seguridad.`,
     choices: [
-      { text: "Encender generadores y revisar", effect: { food: 6, zombies: 2, fuel: -2 } },
-      { text: "Revisar oficinas primero", effect: { materials: 2, ammo: 2, morale: 1 } },
-      { text: "Marcar el lugar para regreso", effect: { karma: 1 } }
-    ]
+      { text: "Excavar y rescatar", effect: { materials: -2, morale: 3, karma: 4, advanceMs: 180000 } },
+      { text: "Dejar agua y marcharse", effect: { water: -1, morale: 1, advanceMs: 60000 } },
+      { text: "Seguir sin mirar atrás", effect: { morale: -2, advanceMs: 30000 } },
+    ],
   },
   {
     id: 221,
-    title: "Procesión detenida",
-    text:
-      "Una pequeña capilla con velas gastadas y bancos volcados. Una caja de donaciones cerrada. Un sotano con olor a humedad.",
+    title: "Apartamento con música antigua",
+    text: `Un viejo tocadiscos suena desde un apartamento del segundo piso.
+La puerta principal está entreabierta y huele a polvo y moho.
+Sobre la mesa hay notas que mencionan un búnker cercano.
+Los cristales rotos indican que alguien salió con prisa hace poco.
+Dentro podría haber mapas y latas o una trampa armada.`,
     choices: [
-      { text: "Abrir la caja de donaciones", effect: { food: 2, water: 2, morale: 1 } },
-      { text: "Bajar al sótano", effect: { zombies: 2, medicine: 1, ammo: 1 } },
-      { text: "Reordenar el lugar y dejar agua", effect: { water: -2, karma: 4, morale: 2 } }
-    ]
+      { text: "Registrar todas las habitaciones", effect: { food: 2, water: 1, zombies: 1, advanceMs: 90000 } },
+      { text: "Tomar solo el mapa y salir", effect: { materials: 1, morale: 1, advanceMs: 60000 } },
+      { text: "Apagar el tocadiscos y retirarse", effect: { threat: -1, advanceMs: 30000 } },
+    ],
   },
   {
     id: 222,
-    title: "Los trajes colgados",
-    text:
-      "Una tintorería con trajes en bolsas. En la trastienda, químicos y mascarillas. Un ventilador hace vibrar las perchas.",
+    title: "Autobús escolar volcado",
+    text: `Un autobús escolar yace de costado en medio de la carretera.
+En su interior aún cuelgan mochilas pequeñas y libros de texto.
+La guantera está cerrada con llave y huele a combustible derramado.
+Las ruedas todavía podrían servir como repuestos para nuestro vehículo.
+El silencio alrededor es inquietante y tenso.`,
     choices: [
-      { text: "Tomar mascarillas y salir", effect: { materials: 1, morale: 1 } },
-      { text: "Rebuscar químicos útiles", effect: { materials: 3, zombies: 1 } },
-      { text: "Bloquear el acceso para otros", effect: { materials: -2, karma: -3 } }
-    ]
+      { text: "Buscar útiles entre las mochilas", effect: { food: 1, water: 1, morale: -1, advanceMs: 90000 } },
+      { text: "Quitar una rueda de repuesto", effect: { materials: 3, advanceMs: 120000 } },
+      { text: "Registrar la guantera y salir", effect: { fuel: 2, zombies: 1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 223,
-    title: "El columpio del parque",
-    text:
-      "Un parque vacío con columpios que chirrían al viento. Un quiosco cerrado tiene bebidas y snacks caducados. Hay huellas pequeñas en la arena recientes.",
+    title: "Ferretería con alarma conectada",
+    text: `La ferretería del barrio aún tiene puertas metálicas intactas.
+Un pequeño generador mantiene una alarma parpadeante sobre la entrada.
+Dentro podrían haber clavos, martillos y herramientas para el campamento.
+Desactivar la alarma requiere habilidad y tiempo concentrado.
+Forzar la entrada atraerá todo tipo de atenciones indeseadas.`,
     choices: [
-      { text: "Abrir el quiosco", effect: { water: 2, food: 3 } },
-      { text: "Seguir las huellas", effect: { survivors: 1, zombies: 1, morale: 2 } },
-      { text: "Anotar la zona como peligrosa", effect: { karma: 1 } }
-    ]
+      { text: "Desactivar la alarma cuidadosamente", effect: { materials: 4, advanceMs: 150000 } },
+      { text: "Romper la puerta de golpe", effect: { materials: 3, threat: 3, zombies: 1, advanceMs: 60000 } },
+      { text: "No arriesgarse y seguir", effect: { advanceMs: 30000, morale: -1 } },
+    ],
   },
   {
     id: 224,
-    title: "Las maletas en la estación",
-    text:
-      "Una estación de buses con decenas de maletas. Muchos bolsillos, algunos candados rotos. Un panel de horarios aún parpadea con rutas inexistentes.",
+    title: "Vecinos discutiendo por comida",
+    text: `Dos grupos de vecinos gritan desde balcones opuestos de un edificio.
+Se acusan mutuamente de robar una bolsa de arroz escondida.
+Uno de ellos ofrece parte del botín si mediamos en la disputa.
+La tensión puede desencadenar disparos si no se calma pronto.
+Nuestro grupo podría ganar aliados o quedar atrapado en la riña.`,
     choices: [
-      { text: "Registrar rápidamente", effect: { food: 3, water: 2, materials: 2 } },
-      { text: "Montar un punto de intercambio", effect: { morale: 3, karma: 4 } },
-      { text: "Aprovechar bolsos para el grupo", effect: { materials: 3, morale: 1 } }
-    ]
+      { text: "Medir con justicia", effect: { food: 2, morale: 2, karma: 3, advanceMs: 120000 } },
+      { text: "Apoyar a un lado", effect: { food: 3, morale: -2, threat: 1, advanceMs: 90000 } },
+      { text: "Ignorar el conflicto", effect: { morale: -1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 225,
-    title: "Pintura fresca",
-    text:
-      "Mensajes recientes en paredes: 'Zona libre más allá del río'. Flechas contradictorias señalan direcciones distintas. Algunos tachones ocultan rostros.",
+    title: "Carreta rota en el camino",
+    text: `Una carreta de madera bloquea el sendero lleno de barro.
+Sus ruedas están dañadas pero hay sacos de grano dentro.
+Los caballos se soltaron y dejaron huellas hacia el bosque oscuro.
+Mover la carreta requiere fuerza y coordinación entre todos.
+Tomar los sacos puede ralentizar la marcha, pero la comida escasea.`,
     choices: [
-      { text: "Seguir una de las flechas", effect: { fuel: -2, zombies: 1, morale: 1 } },
-      { text: "Dejar señales claras para otros", effect: { karma: 4, morale: 2 } },
-      { text: "Ignorar y consolidar posiciones", effect: { materials: 2 } }
-    ]
+      { text: "Reparar y llevar la carreta", effect: { materials: -2, food: 4, advanceMs: 180000 } },
+      { text: "Cargar los sacos al hombro", effect: { food: 3, morale: -1, advanceMs: 150000 } },
+      { text: "Liberar el camino y seguir", effect: { morale: 1, advanceMs: 90000 } },
+    ],
   },
   {
     id: 226,
-    title: "Vagón bloqueado",
-    text:
-      "En la entrada del metro, un vagón descarrilado bloquea dos túneles. Dentro hay mochilas y linternas. Se escuchan arañazos regulares.",
+    title: "Biblioteca aún ordenada",
+    text: `Una biblioteca vieja mantiene sus estantes en perfecto orden.
+Los libros cuentan historias de supervivencia y manuales de primeros auxilios.
+En la recepción hay una caja fuerte con un símbolo de cruz roja.
+Una escalera chirriante conduce a un altillo oscuro y polvoriento.
+El silencio invita a quedarse, pero el tiempo apremia.`,
     choices: [
-      { text: "Entrar y registrar", effect: { materials: 2, water: 2, zombies: 2 } },
-      { text: "Desbloquear un túnel lateral", effect: { materials: -3, morale: 2 } },
-      { text: "Dejar marcas de peligro", effect: { karma: 2 } }
-    ]
+      { text: "Leer manuales útiles", effect: { morale: 2, knowledge: true, advanceMs: 120000 } },
+      { text: "Forzar la caja de la recepción", effect: { medicine: 2, materials: 1, advanceMs: 90000 } },
+      { text: "Tomar mapas y partir", effect: { fuel: 1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 227,
-    title: "La clínica de barrio",
-    text:
-      "Una clínica con carteles de vacunación. La nevera está apagada. Hay botiquines cerrados y formularios desparramados.",
+    title: "Mercado nocturno clandestino",
+    text: `En un callejón oscuro se organiza un mercado solo por la noche.
+Vendedores encapuchados ofrecen piezas robadas y medicamentos raros.
+Se debe pagar con recursos o favores peligrosos para los nuestros.
+La policía ya no existe, pero la violencia sigue latente en cada trato.
+Comprar o robar aquí puede definir nuestras relaciones futuras.`,
     choices: [
-      { text: "Forzar botiquines", effect: { medicine: 3, morale: 1 } },
-      { text: "Buscar registros útiles", effect: { medicine: 2, karma: 1 } },
-      { text: "Sellar ventanas y dejar nota", effect: { materials: -2, karma: 3 } }
-    ]
+      { text: "Comprar medicamentos caros", effect: { medicine: 3, fuel: -2, advanceMs: 150000 } },
+      { text: "Robar entre las sombras", effect: { ammo: 4, morale: -3, karma: -4, advanceMs: 90000 } },
+      { text: "Vigilar y marcharse", effect: { threat: -1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 228,
-    title: "Carretera de espejos",
-    text:
-      "Alguien dispersó espejos en una carretera, quizá para confundir a los infectados. Entre los reflejos, se mueven sombras.",
+    title: "Señales en el techo del banco",
+    text: `En el techo de un banco aparecen flechas pintadas con tiza.
+Señalan hacia un hueco de ventilación parcialmente abierto.
+El interior parece oscuro pero protegido de las calles infectadas.
+Puede ser un refugio temporal o una trampa cerrada sin salida.
+Seguir las señales requiere confianza en desconocidos.`,
     choices: [
-      { text: "Recoger espejos tácticos", effect: { materials: 2, morale: 1 } },
-      { text: "Atravesar a plena luz", effect: { zombies: 1, fuel: -1 } },
-      { text: "Rodear por el campo", effect: { fuel: -2, morale: -1 } }
-    ]
+      { text: "Entrar por la ventilación", effect: { materials: 1, food: 2, zombies: 1, advanceMs: 90000 } },
+      { text: "Dejar nuestras propias señales", effect: { morale: 1, karma: 2, advanceMs: 60000 } },
+      { text: "Ignorar las flechas", effect: { advanceMs: 30000, threat: -1 } },
+    ],
   },
   {
     id: 229,
-    title: "El almacén inundado",
-    text:
-      "Un almacén con agua hasta las rodillas. Flotan cajas, pero algunas parecen intactas. El olor agrio invita a salir rápido.",
+    title: "Casa con jardín bien cuidado",
+    text: `En medio del barrio arrasado hay una casa con jardín intacto.
+Las flores están regadas y la puerta principal se ve recién pintada.
+No se observan marcas de lucha ni signos de abandono.
+Quizá sus dueños estén dentro o hayan salido hace poco de patrulla.
+Entrar sin permiso podría iniciar un conflicto innecesario.`,
     choices: [
-      { text: "Arriesgarse a buscar comida", effect: { food: 5, zombies: 1 } },
-      { text: "Tomar solo lo que flota", effect: { food: 2, water: 1 } },
-      { text: "Cerrar compuertas para drenar", effect: { materials: -3, morale: 2 } }
-    ]
+      { text: "Tocar la puerta y hablar", effect: { morale: 2, karma: 2, advanceMs: 90000 } },
+      { text: "Forzar la entrada discretamente", effect: { food: 2, water: 2, morale: -3, advanceMs: 60000 } },
+      { text: "Marcarla como zona segura y seguir", effect: { advanceMs: 30000, threat: -1 } },
+    ],
   },
   {
     id: 230,
-    title: "Sótano con radio",
-    text:
-      "Un sótano lleno de baterías y radios. Una antena casera en la ventana. Un cuaderno registra mensajes de auxilio de hace semanas.",
+    title: "Estación de metro inundada",
+    text: `Las escaleras del metro conducen a un túnel parcialmente inundado.
+Se escucha un eco metálico de gotas que caen desde el techo roto.
+Un letrero indica que al final existe un refugio preparado años atrás.
+La humedad puede estropear municiones y herramientas sensibles.
+Pasar por allí ahorra camino pero expone a infecciones y caídas.`,
     choices: [
-      { text: "Reparar la antena y emitir", effect: { materials: -2, survivors: 1, morale: 2 } },
-      { text: "Tomar baterías y marchar", effect: { materials: 2, fuel: 1 } },
-      { text: "Dejar un mensaje de rutas", effect: { karma: 3, morale: 1 } }
-    ]
+      { text: "Nadar hasta el refugio", effect: { threat: 2, medicine: -1, morale: -1, advanceMs: 150000 } },
+      { text: "Construir una pasarela improvisada", effect: { materials: -3, advanceMs: 210000 } },
+      { text: "Buscar otra entrada", effect: { fuel: -1, advanceMs: 120000 } },
+    ],
   },
   {
     id: 231,
-    title: "Taller de cerrajería",
-    text:
-      "En una cerrajería hay ganzúas, cerraduras y cajas fuertes pequeñas. El dueño dejó instrucciones para abrir una 'caja de emergencia' oculta.",
+    title: "Furgoneta con mensaje de auxilio",
+    text: `Una furgoneta pintada con la palabra "SOCORRO" yace en una zanja.
+Del interior surge un olor fuerte a combustible y comida descompuesta.
+Hay marcas de uñas en las ventanas desde dentro hacia afuera.
+Quizá alguien quedó atrapado antes de convertirse en amenaza.
+Ignorarla podría dejar atrás herramientas o supervivientes.`,
     choices: [
-      { text: "Abrir la caja de emergencia", effect: { medicine: 1, ammo: 3, morale: 1 } },
-      { text: "Tomar herramientas discretamente", effect: { materials: 3 } },
-      { text: "Dejar un juego de llaves universal", effect: { karma: 4, morale: 2 } }
-    ]
+      { text: "Revisar el interior cuidadosamente", effect: { ammo: 2, food: 1, zombies: 1, advanceMs: 90000 } },
+      { text: "Sacar gasolina y marchar", effect: { fuel: 3, advanceMs: 60000 } },
+      { text: "Remolcarla para piezas", effect: { materials: 3, fuel: -1, advanceMs: 150000 } },
+    ],
   },
   {
     id: 232,
-    title: "Jugadores en la cancha",
-    text:
-      "Un grupo improvisa un partido para olvidar el miedo. Piden que os unáis. Otros creen que perder tiempo es peligroso.",
+    title: "Río con puente derrumbado",
+    text: `El puente principal sobre el río se derrumbó dejando escombros.
+Solo quedan restos metálicos retorcidos sobre el agua agitada.
+Un cartel señala un vado más seguro a varios kilómetros al norte.
+Cruzar a nado con mochilas es casi un suicidio en estas aguas.
+Decidir qué ruta tomar puede cambiar nuestra llegada al refugio.`,
     choices: [
-      { text: "Jugar un rato corto", effect: { morale: 6 } },
-      { text: "Vigilar mientras juegan", effect: { morale: 3, zombies: -1 } },
-      { text: "Negarse y seguir", effect: { morale: -2 } }
-    ]
+      { text: "Intentar cruzar por los restos", effect: { threat: 2, materials: -1, advanceMs: 120000 } },
+      { text: "Buscar el vado al norte", effect: { fuel: -2, advanceMs: 180000 } },
+      { text: "Acampar y esperar ayuda", effect: { food: -1, morale: -1, advanceMs: 240000 } },
+    ],
   },
   {
     id: 233,
-    title: "Cine en penumbra",
-    text:
-      "Un cine antiguo con carteles descoloridos. Palomitas viejas en el suelo. Tras la pantalla, una escalera a la cabina de proyección.",
+    title: "Helicóptero caído en plaza",
+    text: `Un helicóptero militar yace destrozado en medio de una plaza.
+Los restos aún emiten chispas y un rotor sigue girando lentamente.
+Podría haber botiquines o armas dentro del fuselaje.
+La plaza abierta nos deja expuestos a francotiradores y zombis.
+Un humo denso podría ser visto desde kilómetros de distancia.`,
     choices: [
-      { text: "Buscar en la cabina", effect: { materials: 2, fuel: 1 } },
-      { text: "Proyectar luz para atraer y limpiar", effect: { zombies: 2, ammo: -2, morale: 2 } },
-      { text: "Aprovechar butacas para combustible", effect: { fuel: 2, morale: -1 } }
-    ]
+      { text: "Buscar cajas médicas", effect: { medicine: 3, threat: 2, advanceMs: 90000 } },
+      { text: "Tomar piezas del motor", effect: { materials: 4, fuel: 1, advanceMs: 120000 } },
+      { text: "Abandonar la plaza", effect: { morale: -1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 234,
-    title: "La panadería",
-    text:
-      "Una panadería con harina derramada y hornos fríos. Hay sacos cerrados y una libreta de recetas sencillas.",
+    title: "Mensajero herido en la carretera",
+    text: `Un mensajero con uniforme de reparto yace herido junto al camino.
+Su mochila cerrada tiene un logo de empresa y parece pesada.
+Dice llevar documentos para un refugio cercano que podrían salvar vidas.
+Ayudarlo podría incluir cargarlo hasta el campamento o curarlo aquí.
+Robarle y dejarlo sería rápido pero moralmente cuestionable.`,
     choices: [
-      { text: "Tomar harina y utensilios", effect: { food: 4, materials: 1 } },
-      { text: "Hornear algo rápido", effect: { food: 2, morale: 3, zombies: 1 } },
-      { text: "Dejar la receta duplicada", effect: { karma: 2 } }
-    ]
+      { text: "Cargarlo hasta el refugio", effect: { morale: 3, karma: 4, advanceMs: 210000 } },
+      { text: "Curarlo y dejarlo seguir", effect: { medicine: -1, morale: 1, advanceMs: 120000 } },
+      { text: "Tomar la mochila y huir", effect: { food: 2, water: 2, morale: -4, karma: -5, advanceMs: 60000 } },
+    ],
   },
   {
     id: 235,
-    title: "Caravana varada",
-    text:
-      "Una caravana volcó en una zanja. Dentro, mochilas y una caja con botiquines básicos. Hay un rastro de sangre hacia el bosque.",
+    title: "Tienda de electrónica intacta",
+    text: `Una tienda de electrónica mantiene sus vitrinas sin romper.
+Los generadores dentro podrían servir para recargar baterías.
+Se ven drones pequeños y radios selladas en sus cajas originales.
+El sistema de seguridad aún tiene sensores de movimiento activos.
+Abrirla sin disparar las alarmas requiere manos expertas.`,
     choices: [
-      { text: "Rescatar botiquines", effect: { medicine: 3, morale: 1 } },
-      { text: "Seguir el rastro", effect: { survivors: 1, zombies: 1, morale: 2 } },
-      { text: "Aprovechar piezas de la caravana", effect: { materials: 3 } }
-    ]
+      { text: "Desactivar sensores y entrar", effect: { materials: 2, fuel: 1, advanceMs: 150000 } },
+      { text: "Romper el cristal de un golpe", effect: { materials: 3, threat: 2, zombies: 1, advanceMs: 60000 } },
+      { text: "Robar solo lo del mostrador", effect: { ammo: 1, morale: -1, advanceMs: 90000 } },
+    ],
   },
   {
     id: 236,
-    title: "Aula de ciencias",
-    text:
-      "En un liceo, el laboratorio de ciencias tiene alcohol, gasas y cuadernos. El despacho del profesor está cerrado.",
+    title: "Anciano con huerto escondido",
+    text: `Un anciano aparece desde una cabaña señalando un huerto oculto.
+Ofrece zanahorias a cambio de agua limpia para sus plantas.
+Dice que ha visto bandas merodeando la zona durante la noche.
+Su vista se nubla y parece estar cansado de defender el lugar.
+Ayudarlo podría asegurar un aliado o un problema futuro.`,
     choices: [
-      { text: "Forzar el despacho", effect: { medicine: 2, ammo: 1, zombies: 1 } },
-      { text: "Tomar solo material médico", effect: { medicine: 3 } },
-      { text: "Dejar notas de primeros auxilios", effect: { karma: 3, morale: 1 } }
-    ]
+      { text: "Intercambiar agua por verduras", effect: { water: -2, food: 4, morale: 1, advanceMs: 90000 } },
+      { text: "Proponer vigilar por la noche", effect: { threat: -1, morale: 2, advanceMs: 180000 } },
+      { text: "Rehusar y marcharse", effect: { morale: -1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 237,
-    title: "Estación de servicio",
-    text:
-      "Los surtidores están apagados pero el depósito quizá tiene restos. La tienda anexa tiene snacks y mapas viejos.",
+    title: "Barrio inundado con botes",
+    text: `Las calles están cubiertas por agua turbia hasta las rodillas.
+En algunas azoteas hay botes pequeños amarrados con cuerdas.
+Podríamos usar un bote para cruzar rápido o saquear casas en alto.
+Pero moverse en el agua atrae a criaturas escondidas bajo la superficie.
+El olor a humedad y gasolina se mezcla con basura flotante.`,
     choices: [
-      { text: "Sifonear combustible", effect: { fuel: 4, zombies: 1 } },
-      { text: "Registrar la tienda", effect: { food: 2, water: 2, morale: 1 } },
-      { text: "Marcar precios justos para trueque", effect: { karma: 3 } }
-    ]
+      { text: "Tomar un bote y cruzar", effect: { fuel: -1, threat: 2, advanceMs: 150000 } },
+      { text: "Saquear una casa elevada", effect: { food: 2, water: 2, zombies: 1, advanceMs: 120000 } },
+      { text: "Bordear el barrio", effect: { fuel: -2, advanceMs: 180000 } },
+    ],
   },
   {
     id: 238,
-    title: "Callejón con trampas",
-    text:
-      "El Callejón está lleno de latas colgantes que suenan con el viento. Quizá alguien vive cerca. Una puerta lateral entreabierta invita a mirar.",
+    title: "Autopista con señales contradictorias",
+    text: `Dos señales en la autopista apuntan a refugios distintos.
+Una está escrita a mano con pintura fresca, la otra es oficial pero vieja.
+Los autos abandonados alrededor muestran impactos de bala recientes.
+Decidir rápido evita quedar expuestos en el descampado.
+La elección podría llevarnos a ayuda o a una emboscada.`,
     choices: [
-      { text: "Avanzar con sigilo", effect: { materials: 2, zombies: -1 } },
-      { text: "Llamar y esperar respuesta", effect: { survivors: 1, morale: 1 } },
-      { text: "Cortar las latas y seguir", effect: { materials: 1, karma: -2 } }
-    ]
+      { text: "Seguir la señal oficial", effect: { fuel: -1, morale: 1, advanceMs: 90000 } },
+      { text: "Confiar en la señal pintada", effect: { fuel: -1, threat: 2, advanceMs: 90000 } },
+      { text: "Acampar y analizar mapas", effect: { food: -1, morale: -1, advanceMs: 180000 } },
+    ],
   },
   {
     id: 239,
-    title: "Puesto fronterizo",
-    text:
-      "Un control policial abandonado con chalecos, baterías y un botiquín marcado con una cruz. La caseta huele a humo reciente.",
+    title: "Estación de servicio ocupada",
+    text: `Una banda armada vigila una estación de servicio bien defendida.
+Piden una parte de nuestro combustible a cambio de dejarnos pasar.
+El líder promete que no dispararán si colaboramos sin preguntas.
+Nuestros vehículos necesitan llenar el tanque antes de seguir.
+Negociar mal podría terminar en un tiroteo peligroso.`,
     choices: [
-      { text: "Tomar chalecos y botiquín", effect: { medicine: 2, materials: 2 } },
-      { text: "Investigar el área", effect: { ammo: 2, zombies: 1 } },
-      { text: "Dejar una nota de advertencia", effect: { karma: 2 } }
-    ]
+      { text: "Pagar lo exigido", effect: { fuel: -4, morale: 1, advanceMs: 90000 } },
+      { text: "Intentar robar de noche", effect: { fuel: 5, threat: 3, karma: -3, advanceMs: 150000 } },
+      { text: "Buscar otra estación", effect: { fuel: -2, advanceMs: 180000 } },
+    ],
   },
   {
     id: 240,
-    title: "Colonia de gatos",
-    text:
-      "Una colonia de gatos ocupa un patio interior. Hay platos, latas abiertas y una bodega con pienso. Los maullidos atraen curiosos.",
+    title: "Refugio subterráneo sellado",
+    text: `En el bosque hay una compuerta metálica con un símbolo de refugio.
+El panel electrónico pide un código que no tenemos.
+Quizá dentro haya comida enlatada y baterías para meses.
+Forzarla podría activar trampas defensivas aún operativas.
+La lluvia empieza a caer y dificulta el trabajo de ganzúa.`,
     choices: [
-      { text: "Tomar pienso para atraer presas", effect: { materials: 1, morale: 1 } },
-      { text: "Dejar comida y marchar", effect: { food: -1, karma: 3, morale: 2 } },
-      { text: "Crear un refugio discreto", effect: { materials: -2, morale: 3 } }
-    ]
+      { text: "Intentar abrir con herramientas", effect: { materials: -2, threat: 1, advanceMs: 180000 } },
+      { text: "Buscar pistas en los alrededores", effect: { morale: 1, advanceMs: 90000 } },
+      { text: "Dejarlo para otra ocasión", effect: { advanceMs: 60000 } },
+    ],
   },
   {
     id: 241,
-    title: "Aparcadero hundido",
-    text:
-      "Un estacionamiento subterráneo con charcos de aceite. Un par de autos tienen el capó abierto y herramientas a la vista.",
+    title: "Tren detenido con vagones vacíos",
+    text: `Un tren de mercancías está detenido en medio de la vía principal.
+Los vagones abiertos muestran cajas de madera parcialmente vacías.
+Los alrededores están silenciosos salvo por el viento que silba.
+Podríamos mover algunas cajas para revisar lo que queda adentro.
+Demorarnos aquí expone a ataques desde la línea de árboles.`,
     choices: [
-      { text: "Recoger herramientas", effect: { materials: 3, morale: 1 } },
-      { text: "Intentar arrancar un coche", effect: { fuel: 2, zombies: 1 } },
-      { text: "Desactivar alarmas para otros", effect: { karma: 2 } }
-    ]
+      { text: "Examinar vagones uno por uno", effect: { materials: 3, food: 1, advanceMs: 150000 } },
+      { text: "Tomar solo lo visible", effect: { materials: 1, advanceMs: 60000 } },
+      { text: "Seguir las vías a pie", effect: { fuel: -1, morale: -1, advanceMs: 120000 } },
+    ],
   },
   {
     id: 242,
-    title: "Tienda de camping",
-    text:
-      "Sacochos, sogas, cantimploras. Un pasillo con hornillos y gas. El escaparate tiene grietas peligrosas.",
+    title: "Montón de cartas sin enviar",
+    text: `En una oficina postal derruida hay sacos llenos de cartas sin enviar.
+Muchas están selladas con promesas y despedidas escritas a mano.
+El mapa del barrio muestra algunas direcciones aún accesibles.
+Entregar cartas podría levantar la moral de desconocidos y propia.
+Quemarlas serviría como señal de humo para otros supervivientes.`,
     choices: [
-      { text: "Equiparse para travesía", effect: { materials: 3, water: 1 } },
-      { text: "Tomar gas y hornillos", effect: { fuel: 3 } },
-      { text: "Refuerzo de escaparate", effect: { materials: -2, karma: 3 } }
-    ]
+      { text: "Repartir algunas cartas", effect: { morale: 3, karma: 4, advanceMs: 180000 } },
+      { text: "Usarlas para encender una señal", effect: { threat: -1, advanceMs: 90000 } },
+      { text: "Tomar sellos y marchar", effect: { materials: 1, advanceMs: 60000 } },
+    ],
   },
   {
     id: 243,
-    title: "Guardería de adultos",
-    text:
-      "Un centro de día para mayores. Sillas de ruedas, mantas y un armario con medicación básica. Una puerta se mueve con golpes suaves.",
+    title: "Aparición en el espejo de la tienda",
+    text: `Un espejo en una tienda rota refleja una figura que no vemos al girarnos.
+Algunos creen que es superstición, otros temen un francotirador escondido.
+Debajo del mostrador hay un cajón con llave que podría contener algo útil.
+El reflejo podría ser un montaje para distraer a los curiosos.
+Decidir rápido evita que la paranoia consuma al grupo.`,
     choices: [
-      { text: "Tomar medicación y mantas", effect: { medicine: 2, materials: 1 } },
-      { text: "Abrir la puerta con cuidado", effect: { survivors: 1, zombies: 1, morale: 2 } },
-      { text: "Sellar y dejar una marca", effect: { materials: -1, karma: 2 } }
-    ]
+      { text: "Investigar el reflejo", effect: { threat: 1, advanceMs: 60000 } },
+      { text: "Forzar el cajón rápidamente", effect: { ammo: 2, morale: -1, advanceMs: 90000 } },
+      { text: "Romper el espejo y retirarse", effect: { materials: 1, advanceMs: 30000 } },
+    ],
   },
   {
     id: 244,
-    title: "Plaza de trueque",
-    text:
-      "Varias personas han dejado cajas selladas con etiquetas: 'cambio'. Se ve munición, latas y una caja de herramientas. Nadie a la vista.",
+    title: "Hospital con generador activo",
+    text: `Un hospital pequeño mantiene luces gracias a un generador que zumba.
+Las puertas de urgencias están cerradas con muebles desde dentro.
+Se escuchan gritos débiles y golpes metálicos en los pasillos.
+El generador podría abastecer al campamento por una semana.
+Entrar requiere desmantelar barricadas y arriesgar contagio.`,
     choices: [
-      { text: "Intercambiar con honestidad", effect: { ammo: -2, food: 4, morale: 2, karma: 4 } },
-      { text: "Tomar lo necesario y dejar poco", effect: { food: 2, ammo: 1, karma: -4 } },
-      { text: "Ordenar y dejar normas claras", effect: { materials: -1, morale: 2, karma: 5 } }
-    ]
+      { text: "Entrar a rescatar pacientes", effect: { medicine: 3, zombies: 2, karma: 3, advanceMs: 150000 } },
+      { text: "Robar el generador", effect: { fuel: 4, threat: 2, morale: -2, advanceMs: 120000 } },
+      { text: "Dejar el lugar tranquilo", effect: { advanceMs: 60000 } },
+    ],
   },
   {
     id: 245,
-    title: "Búnker sin dueño",
-    text:
-      "Una entrada de búnker con combinación rota. Dentro, estantes vacíos pero una caja fuerte pequeña empotrada. Un plano indica un depósito secundario.",
+    title: "Ventisca repentina en carretera",
+    text: `Una ventisca fría azota la carretera levantando nieve y polvo.
+La visibilidad se reduce a pocos metros y el viento corta la piel.
+Encontrar refugio rápido es vital para evitar hipotermia.
+Seguir conduciendo puede hacer que el vehículo derrape y se estrelle.
+Perder tiempo buscando abrigo afectará el progreso del día.`,
     choices: [
-      { text: "Abrir la caja fuerte", effect: { bunker_key: true, ammo: 2, morale: 1 } },
-      { text: "Seguir el plano al depósito", effect: { food: 3, water: 3, zombies: 2 } },
-      { text: "Sellar la entrada para otros", effect: { materials: -2, karma: 3 } }
-    ]
-  }
+      { text: "Refugiarse en una casa cercana", effect: { morale: 1, threat: -1, advanceMs: 120000 } },
+      { text: "Seguir conduciendo lentamente", effect: { fuel: -2, advanceMs: 90000 } },
+      { text: "Montar un campamento improvisado", effect: { materials: -2, food: -1, advanceMs: 150000 } },
+    ],
+  },
 ];
 


### PR DESCRIPTION
## Summary
- track per-day combat, exploration and decision stats
- show end-of-day summary overlay with reason and next-day transition
- replace decision deck with 45-card Day 1 set including time penalties

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8e939a8bc83259769d79dbbd155d7