### PR TITLE
Normalize combat log messages to single line

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,7 +216,11 @@ export default function App(){
   const tw = useTypewriterQueue();
   // helper para pushear mensajes al panel
   function pushBattle(text: string, onDone?: () => void){
-    tw.push({ text, onDone });
+    const clean = text
+      .replace(/\s*\n+\s*/g, " ")
+      .replace(/\s{2,}/g, " ")
+      .trim();
+    tw.push({ text: clean, onDone });
   }
 
   const [foundNotes, setFoundNotes] = useState<GameNote[]>([]);
@@ -668,7 +672,7 @@ export default function App(){
     if (foundNext) {
       const prevName = activePlayer ? activePlayer.name : "Jugador";
       const nextName = alivePlayers[nextIdx].name;
-      pushBattle(`${prevName} tu turno ha terminado\nahora le toca a: ${nextName}`, () => {
+      pushBattle(`${prevName} tu turno ha terminado — ahora le toca a: ${nextName}`, () => {
         setTurn(nextIdx);
       });
     } else {

--- a/src/components/CombatLogPanel.tsx
+++ b/src/components/CombatLogPanel.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 
 export default function CombatLogPanel({
-  text, typing, onEnter,
-  currentActor, // nombre del que actúa (jugador o enemigo)
+  text,
+  typing,
+  onEnter,
+  currentActor, // nombre del actor en turno (jugador o enemigo)
 }: {
   text: string;
   typing: boolean;
@@ -17,17 +19,46 @@ export default function CombatLogPanel({
     return () => window.removeEventListener("keydown", onKey);
   }, [onEnter]);
 
+  // Normaliza a UNA sola línea: quita saltos y espacios múltiples
+  const oneLine = useMemo(() => {
+    return (text ?? "")
+      .replace(/\s*\n+\s*/g, " ")
+      .replace(/\s{2,}/g, " ")
+      .trim();
+  }, [text]);
+
   return (
     <div className="my-3 rounded-xl border border-neutral-800 bg-neutral-900/80 px-4 py-3 shadow-inner">
+      {/* Efecto 'breath' definido localmente */}
+      <style>{`
+        @keyframes breath {
+          0%, 100% { opacity: 0.35; }
+          50% { opacity: 1; }
+        }
+        .breath {
+          animation: breath 1.8s ease-in-out infinite;
+        }
+      `}</style>
+
       <div className="flex items-center gap-3">
         {currentActor && (
-          <div className="text-xs px-2 py-1 rounded bg-emerald-700/30 border border-emerald-600/40">
+          <div className="text-xs px-2 py-1 rounded bg-emerald-700/30 border border-emerald-600/40 whitespace-nowrap">
             Turno: <span className="font-semibold">{currentActor}</span>
           </div>
         )}
-        <div className="text-sm text-neutral-200 flex-1 whitespace-pre-wrap">
-          {text}{!typing && text ? `\n\nPresiona Enter para continuar` : ""}
+
+        {/* Mensaje en UNA sola línea, sin wraps */}
+        <div
+          className="flex-1 text-sm text-neutral-200 whitespace-nowrap overflow-hidden"
+          title={oneLine} // tooltip por si se corta
+        >
+          {oneLine}
         </div>
+      </div>
+
+      {/* Aviso inferior con parpadeo lento (breath) */}
+      <div className="mt-1 text-center text-xs text-neutral-400 breath select-none">
+        Presiona Enter para continuar
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace CombatLogPanel with one-line display and animated “Press Enter” prompt
- Sanitize pushBattle helper to strip newlines and excess spaces
- Update turn transition message to use a single line

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8ec9703cc8325a485a204a25c5899