### PR TITLE
feat: add flavored combat phrases

### DIFF
--- a/src/data/combatPhrases.ts
+++ b/src/data/combatPhrases.ts
@@ -1,30 +1,199 @@
-const MELEE_MISS = [
+export type TplVars = { P?: string; E?: string; W?: string; D?: number; V?: number };
+
+export function render(tpl: string, v: TplVars) {
+  return tpl
+    .replaceAll("${P}", v.P ?? "")
+    .replaceAll("${E}", v.E ?? "")
+    .replaceAll("${W}", v.W ?? "")
+    .replaceAll("${D}", v.D != null ? String(v.D) : "")
+    .replaceAll("${V}", v.V != null ? String(v.V) : "");
+}
+export function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// --- CATEGORIZACIÓN DE ARMAS PARA FRASES ---
+export type WeaponFlavor =
+  | "fists"
+  | "melee_blade"
+  | "melee_blunt"
+  | "ranged_pistol"
+  | "ranged_rifle"
+  | "ranged_shotgun"
+  | "ranged_smg"
+  | "ranged_xbow"
+  | "ranged_sling"
+  | "melee_other"
+  | "ranged_other";
+
+const bladeIds = new Set(["knife","dagger","kukri","machete","katana","saw","sdriver","bottle","axe","faxe"]);
+const bluntIds = new Set(["bat","nailbat","pipe","pipehd","hammer","wrench","crowbar","club","mace","shovel","pick","chain"]);
+const pistolIds = new Set(["pistol"]);
+const rifleIds = new Set(["rifle"]);
+const shotgunIds = new Set(["shotgun"]);
+const smgIds = new Set(["smg"]);
+const xbowIds = new Set(["xbow"]);
+const slingIds = new Set(["sling"]);
+
+export function weaponFlavorFrom(id: string, name: string, type: "melee"|"ranged"): WeaponFlavor {
+  const lid = (id || "").toLowerCase();
+  const lname = (name || "").toLowerCase();
+  if (lid === "fists" || lname.includes("puño")) return "fists";
+  if (type === "melee") {
+    if (bladeIds.has(lid) || /cuchi|machete|katana|sierra|daga|corte|hacha/.test(lname)) return "melee_blade";
+    if (bluntIds.has(lid) || /bate|tubo|martillo|llave|palanca|garrote|maza|pala|pico|cadena/.test(lname)) return "melee_blunt";
+    return "melee_other";
+  } else {
+    if (pistolIds.has(lid) || /pistol/.test(lname)) return "ranged_pistol";
+    if (rifleIds.has(lid) || /rifle/.test(lname)) return "ranged_rifle";
+    if (shotgunIds.has(lid) || /escopeta|shotgun/.test(lname)) return "ranged_shotgun";
+    if (smgIds.has(lid) || /subfusil|smg/.test(lname)) return "ranged_smg";
+    if (xbowIds.has(lid) || /ballesta|xbow/.test(lname)) return "ranged_xbow";
+    if (slingIds.has(lid) || /honda/.test(lname)) return "ranged_sling";
+    return "ranged_other";
+  }
+}
+
+// --- FRASES DE ÉXITO (se añaden “colas” de estado si aplica) ---
+export const HIT_FISTS = [
+  "${P} suelta un puñetazo directo a ${E} (−${D}).",
+  "Con los puños, ${P} impacta a ${E} (−${D}).",
+  "${P} conecta un derechazo contra ${E} (−${D}).",
+  "Golpe en corto: ${P} sacude a ${E} (−${D}).",
+  "${P} martilla con los nudillos a ${E} (−${D}).",
+  "Un gancho preciso de ${P} da a ${E} (−${D}).",
+];
+
+export const HIT_MELEE_BLADE = [
+  "${P} corta a ${E} con ${W} (−${D}).",
+  "${P} desliza ${W} y abre defensa de ${E} (−${D}).",
+  "Filo certero: ${P} hiere a ${E} con ${W} (−${D}).",
+  "${W} silba y alcanza a ${E} (−${D}).",
+  "${P} asesta un tajo con ${W} (−${D}).",
+  "Con ${W}, ${P} busca arterias y golpea (−${D}).",
+];
+
+export const HIT_MELEE_BLUNT = [
+  "${P} descarga ${W} contra ${E} (−${D}).",
+  "Golpe contundente: ${P} aplasta a ${E} con ${W} (−${D}).",
+  "${W} cruje sobre ${E} (−${D}).",
+  "Impacto seco de ${P} con ${W} en ${E} (−${D}).",
+  "${P} balancea ${W} y tumba a ${E} (−${D}).",
+  "Golpazo de ${W} directo a ${E} (−${D}).",
+];
+
+export const HIT_PISTOL = [
+  "${P} dispara ${W} a ${E} (−${D}).",
+  "Tiro controlado: ${P} impacta a ${E} con ${W} (−${D}).",
+  "La bala de ${W} alcanza a ${E} (−${D}).",
+  "Disparo limpio de ${P} con ${W} (−${D}).",
+  "${P} aprieta el gatillo y hiere a ${E} (−${D}).",
+];
+
+export const HIT_RIFLE = [
+  "${P} apunta con ${W} y perfora a ${E} (−${D}).",
+  "Tiro a distancia: ${P} castiga a ${E} con ${W} (−${D}).",
+  "El proyectil de ${W} atraviesa cobertura (−${D}).",
+  "Disparo preciso de ${P} con ${W} (−${D}).",
+  "Ráfaga controlada de ${W} contra ${E} (−${D}).",
+];
+
+export const HIT_SHOTGUN = [
+  "${P} suelta una descarga de ${W} sobre ${E} (−${D}).",
+  "Perdigones de ${W} muerden a ${E} (−${D}).",
+  "A bocajarro: ${P} castiga con ${W} (−${D}).",
+  "Trueno de ${W}: ${E} recibe impacto (−${D}).",
+  "Escopetazo de ${P} que sacude a ${E} (−${D}).",
+];
+
+export const HIT_SMG = [
+  "Ráfaga corta de ${W}: ${E} recibe plomo (−${D}).",
+  "${P} barre con ${W} y alcanza a ${E} (−${D}).",
+  "Control de retroceso: ${P} acierta con ${W} (−${D}).",
+  "Corta ráfaga de ${W} contra ${E} (−${D}).",
+  "Trac-trac de ${W}: ${E} es impactado (−${D}).",
+];
+
+export const HIT_XBOW = [
+  "Un virote de ${W} alcanza a ${E} (−${D}).",
+  "${P} tensa ${W} y clava en ${E} (−${D}).",
+  "Silencio letal: ${W} impacta a ${E} (−${D}).",
+  "Tiro certero de ${W}: ${E} sufre (−${D}).",
+  "El virote se incrusta en ${E} (−${D}).",
+];
+
+export const HIT_SLING = [
+  "Piedra de ${W} da en ${E} (−${D}).",
+  "${P} suelta la honda y golpea a ${E} (−${D}).",
+  "Proyectil improvisado con ${W} alcanza a ${E} (−${D}).",
+  "Tiro de ${W} directo a ${E} (−${D}).",
+  "La piedra rebota y hiere a ${E} (−${D}).",
+];
+
+// --- FRASES DE FALLO (10 cada una) ---
+export const MISS_MELEE = [
   "¡${P} falla el golpe con ${W}!",
   "${P} balancea ${W}, pero ${E} esquiva a último segundo.",
-  "${P} duda un instante y el golpe con ${W} no conecta.",
-  "Un mal ángulo: ${P} no logra impactar con ${W}.",
+  "${P} duda y el golpe con ${W} no conecta.",
+  "Mal ángulo: ${P} no impacta con ${W}.",
   "¡${E} se aparta! ${P} falla con ${W}.",
-  "El suelo resbala, ${P} pierde la postura y falla con ${W}.",
-  "La guardia de ${E} detiene el ataque de ${P}.",
+  "El suelo resbala: ${P} pierde postura.",
+  "La guardia de ${E} detiene a ${P}.",
   "${P} golpea el aire; ${E} ya no estaba allí.",
   "Un bloqueo apresurado frena el ${W} de ${P}.",
-  "${P} falla el ataque; ${E} se esconde entre sombras."
+  "${P} erra el ataque; ${E} se oculta entre sombras.",
 ];
 
-const RANGED_MISS = [
-  "${P} dispara a ${E}, pero erra el tiro.",
-  "El disparo de ${P} pasa zumbando junto a ${E}.",
-  "¡Traba en ${W}! ${P} no puede disparar a tiempo.",
-  "${P} apunta rápido; ${E} se cubre y el tiro falla.",
-  "Viento cruzado: el disparo de ${P} no da en el blanco.",
-  "${W} retrocede mal y el tiro de ${P} falla.",
+export const MISS_RANGED = [
+  "${P} dispara ${W}, pero falla a ${E}.",
+  "El tiro de ${P} pasa zumbando junto a ${E}.",
+  "¡Traba en ${W}! ${P} no dispara a tiempo.",
+  "${P} apunta; ${E} se cubre y el tiro falla.",
+  "Viento cruzado: el disparo no da en el blanco.",
+  "Retroceso de ${W}: el tiro se va alto.",
   "Polvo en el cañón: ${P} pierde precisión.",
   "¡Clic! Munición mal alimentada en ${W}.",
-  "El fogonazo desorienta y ${P} falla el disparo.",
-  "${P} pierde línea de tiro; ${E} se oculta."
+  "El fogonazo desorienta y ${P} falla.",
+  "${P} pierde línea de tiro; ${E} se oculta.",
 ];
 
-const HEAL_LINES = [
+// --- COLAS DE ESTADO PARA AÑADIR CUANDO APLICA ---
+export const TAIL_BLEED = [
+  " Deja sangrando a ${E}.",
+  " La herida abre sangrado en ${E}.",
+  " ${E} comienza a sangrar.",
+];
+export const TAIL_STUN = [
+  " ${E} queda aturdido.",
+  " Impacto a la sien: ${E} se aturde.",
+  " ${E} tambalea, aturdido.",
+];
+export const TAIL_INFECT = [
+  " La infección se propaga en ${E}.",
+  " Herida sucia: posible infección en ${E}.",
+  " ${E} muestra signos de infección.",
+];
+
+// Selección por flavor
+export function hitPhraseByFlavor(flavor: WeaponFlavor): string[] {
+  switch (flavor) {
+    case "fists": return HIT_FISTS;
+    case "melee_blade": return HIT_MELEE_BLADE;
+    case "melee_blunt": return HIT_MELEE_BLUNT;
+    case "ranged_pistol": return HIT_PISTOL;
+    case "ranged_rifle": return HIT_RIFLE;
+    case "ranged_shotgun": return HIT_SHOTGUN;
+    case "ranged_smg": return HIT_SMG;
+    case "ranged_xbow": return HIT_XBOW;
+    case "ranged_sling": return HIT_SLING;
+    case "melee_other": return HIT_MELEE_BLUNT;
+    case "ranged_other": return HIT_PISTOL;
+    default: return HIT_FISTS;
+  }
+}
+
+// --- FRASES ADICIONALES ---
+export const HEAL_LINES = [
   "${P} se vende con medicina (+${V} PV).",
   "${P} aplica antiséptico y suturas (+${V} PV).",
   "${P} toma analgésicos y respira mejor (+${V} PV).",
@@ -34,11 +203,10 @@ const HEAL_LINES = [
   "La compresa reduce el sangrado: ${P} (+${V} PV).",
   "Una inyección oportuna; ${P} mejora (+${V} PV).",
   "${P} cierra la herida y se recompone (+${V} PV).",
-  "${P} administra dosis precisa: vigor recuperado (+${V} PV)."
+  "${P} administra dosis precisa: vigor recuperado (+${V} PV).",
 ];
 
-const FLEE_LINES = [
-  // 20 frases de huida
+export const FLEE_LINES = [
   "${P} se abre paso entre escombros y se aleja.",
   "${P} corre por un pasillo estrecho y escapa.",
   "${P} usa una puerta lateral y desaparece.",
@@ -58,42 +226,5 @@ const FLEE_LINES = [
   "Un salto a la azotea; ${P} se escabulle.",
   "${P} se cuela por una ventana rota.",
   "Con una voltereta, ${P} cae fuera del alcance.",
-  "${P} desaparece detrás de un camión volcado."
+  "${P} desaparece detrás de un camión volcado.",
 ];
-
-const ENEMY_HIT = [
-  "${E} embiste a ${P} (-${V} PV).",
-  "${E} muerde el brazo de ${P} (-${V} PV).",
-  "${E} derriba a ${P} de un empujón (-${V} PV).",
-  "Uñas desgarran: ${E} hiere a ${P} (-${V} PV).",
-  "Un zarpazo de ${E} alcanza a ${P} (-${V} PV).",
-  "${E} golpea a ${P} con furia (-${V} PV).",
-  "${E} muerde y no suelta: ${P} sufre (-${V} PV).",
-  "Cabeza contra muro: ${E} aturde a ${P} (-${V} PV).",
-  "${E} clava dientes en ${P} (-${V} PV).",
-  "Con torpeza brutal, ${E} lastima a ${P} (-${V} PV)."
-];
-
-const ENEMY_MISS = [
-  "${E} falla: ${P} se aparta.",
-  "${E} tropieza y no alcanza a ${P}.",
-  "${P} esquiva con un giro.",
-  "${E} se estrella contra la pared.",
-  "Un quiebre de cintura salva a ${P}.",
-  "${P} interpone el antebrazo y resiste.",
-  "${E} calcula mal la distancia.",
-  "Un paso atrás y ${E} erra.",
-  "${P} se agacha justo a tiempo.",
-  "Ataque torpe de ${E}: falla."
-];
-
-function renderTpl(tpl: string, vars: Record<string,string|number>){
-  return tpl
-    .replaceAll("${P}", String(vars.P ?? "Jugador"))
-    .replaceAll("${E}", String(vars.E ?? "Enemigo"))
-    .replaceAll("${W}", String(vars.W ?? "arma"))
-    .replaceAll("${V}", String(vars.V ?? ""));
-}
-function pick(arr: string[]){ return arr[Math.floor(Math.random()*arr.length)]; }
-
-export { MELEE_MISS, RANGED_MISS, HEAL_LINES, FLEE_LINES, ENEMY_HIT, ENEMY_MISS, renderTpl, pick };


### PR DESCRIPTION
## Summary
- expand combat phrase data with weapon flavor categorization, hit/miss templates and state tails
- update player and enemy attack flows to use new phrases and append bleed/stun/infection notes
- adjust heal and flee actions to use new rendering helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8f489198c832594b5cd68161b4342