### PR TITLE
Add counterattack mode and infection statuses

### DIFF
--- a/src/components/overlays/InfectionFatalModal.tsx
+++ b/src/components/overlays/InfectionFatalModal.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export default function InfectionFatalModal({ open, playerName, onClose }:{
+  open:boolean; playerName:string; onClose:()=>void;
+}){
+  if(!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+      <div className="relative z-10 max-w-lg w-full mx-4 rounded-2xl p-6 bg-zinc-900/95 border border-white/10 shadow-xl">
+        <p className="text-sm mb-4">
+          <b>{playerName}</b> no aguantó la infección y tuvimos que sacrificarlo al ver que ya era parte de ellos...
+        </p>
+        <div className="flex justify-end">
+          <button className="px-3 py-2 rounded-xl bg-red-600 hover:bg-red-500" onClick={onClose}>
+            Seguir adelante
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,10 @@ button { cursor: pointer; }
 @keyframes fade-in { from { opacity: 0; transform: translateY(10px);} to { opacity:1; transform: translateY(0);} }
 .animate-fade-in { animation: fade-in .3s ease-out; }
 .animate-pulse-slow{animation:pulse 2.2s ease-in-out infinite;}
+
+@keyframes breathFast { 0%{opacity:.65} 50%{opacity:1} 100%{opacity:.65} }
+.animate-breath-fast { animation: breathFast 1.1s ease-in-out infinite; }
+
+/* simulación de brillo neón */
+.neon-red { box-shadow: 0 0 14px rgba(255, 0, 64, .65); }
+.neon-green { box-shadow: 0 0 14px rgba(0, 255, 127, .65); }

--- a/src/systems/status.ts
+++ b/src/systems/status.ts
@@ -1,25 +1,58 @@
 export type ConditionId = 'bleeding'|'infected'|'stunned';
-export type ConditionInfo = { id: ConditionId; turnsLeft?: number; intensity?: number; persistent?: boolean; };
+export type ConditionInfo = {
+  id: ConditionId;
+  turnsLeft?: number;
+  intensity?: number;
+  persistent?: boolean;
+  // NUEVO: para infección con cuenta atrás en ms (epoch ms)
+  expiresAtMs?: number;
+};
 export type Conditions = Partial<Record<ConditionId, ConditionInfo>>;
 
 export function hasCondition(c: Conditions|undefined, id: ConditionId){ return !!c && !!c[id]; }
 export function addCondition(c: Conditions|undefined, info: ConditionInfo): Conditions { return { ...(c ?? {}), [info.id]: info }; }
 export function removeCondition(c: Conditions|undefined, id: ConditionId): Conditions { const n={...(c??{})}; delete n[id]; return n; }
 
+// Al inicio de turno:
+// - stunned: salta turno (1 turno) y decrece turnsLeft
+// - infected: deshabilita actuar mientras dure (se gestiona muerte por temporizador fuera)
+// - bleeding: no bloquea actuar, pero causa -2 HP al INICIO del turno
 export function applyStartOfTurnConditions(actor:{name:string;maxHp:number;hp:number;conditions?:Conditions}, log:(s:string)=>void){
-  let skipAction=false; let newC:Conditions={...(actor.conditions??{})};
+  let skipAction=false; let hpDelta=0; let newC:Conditions={...(actor.conditions??{})};
+
   const st=newC.stunned;
-  if(st){ if(Math.random()<0.25){ log(`😵 ${actor.name} está aturdido y no logra actuar este turno.`); skipAction=true; }
-    if(typeof st.turnsLeft==='number'){ const tl=Math.max(0,st.turnsLeft-1); newC=tl===0?removeCondition(newC,'stunned'):addCondition(newC,{...st,turnsLeft:tl}); } }
-  return { skipAction, newConditions:newC };
+  if(st){
+    log(`😵 ${actor.name} está aturdido y pierde este turno.`);
+    skipAction=true;
+    if(typeof st.turnsLeft==='number'){
+      const tl=Math.max(0,st.turnsLeft-1);
+      newC = tl===0 ? removeCondition(newC,'stunned') : addCondition(newC,{...st,turnsLeft:tl});
+    }else{
+      // por defecto un turno
+      newC = removeCondition(newC,'stunned');
+    }
+  }
+
+  const inf=newC.infected;
+  if(inf){
+    // Infectado: deshabilita actuar; la muerte por tiempo se comprueba fuera (App)
+    skipAction=true;
+    log(`🧪 ${actor.name} está infectado y no puede actuar hasta curarse.`);
+  }
+
+  const bleed=newC.bleeding;
+  if(bleed){
+    hpDelta -= 2; // daño fijo
+    log(`🩸 ${actor.name} sangra (-2 PV).`);
+    // bleeding es persistente hasta curarse con "Curar"
+  }
+
+  return { skipAction, hpDelta, newConditions:newC };
 }
 
+// Al final de turno no hacemos nada adicional (el sangrado ya se aplicó al inicio)
 export function applyEndOfTurnConditions(actor:{name:string;maxHp:number;hp:number;conditions?:Conditions}, log:(s:string)=>void){
-  let hpDelta=0; let newC:Conditions={...(actor.conditions??{})};
-  const bleed=newC.bleeding; if(bleed){ const dmg=Math.max(1,Math.floor(actor.maxHp/16)); hpDelta-=dmg; log(`🩸 ${actor.name} sangra (-${dmg} PV).`);
-    if(typeof bleed.turnsLeft==='number'){ const tl=Math.max(0,bleed.turnsLeft-1); newC=tl===0?removeCondition(newC,'bleeding'):addCondition(newC,{...bleed,turnsLeft:tl}); } }
-  const inf=newC.infected; if(inf){ const dmg=Math.max(1,Math.floor(actor.maxHp/8)); hpDelta-=dmg; log(`🧪 La infección avanza en ${actor.name} (-${dmg} PV).`); }
-  return { hpDelta, newConditions:newC };
+  return { hpDelta: 0, newConditions:{...(actor.conditions??{})} };
 }
 
 export function cureCondition(c:Conditions|undefined, id:ConditionId){ return removeCondition(c,id); }


### PR DESCRIPTION
## Summary
- Implement bleeding, infected, and stunned statuses with start of turn effects
- Add enemy counterattacks on player misses and infection death modal
- Style survivor cards with status indicators and neon animations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b933fa2f908325b0b2622565c62b7d