### PR TITLE
feat: ally healing and counterattacks

### DIFF
--- a/src/components/overlays/HealAllyModal.tsx
+++ b/src/components/overlays/HealAllyModal.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { hasCondition } from "../../systems/status";
+
+export default function HealAllyModal({
+  open, players, onPick, onClose
+}:{
+  open:boolean;
+  players: any[]; // {id,name,hp,conditions,backpack?}
+  onPick: (playerId:string)=>void;
+  onClose: ()=>void;
+}){
+  if(!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+      <div className="relative z-10 max-w-lg w-full mx-4 rounded-2xl p-6 bg-zinc-900/95 border border-white/10 shadow-xl">
+        <h3 className="text-lg font-bold mb-2">Curar aliado</h3>
+        <p className="text-xs opacity-80 mb-3">Elige a quién asistir. La infección requiere <b>1 medicina</b>. El sangrado se detiene sin medicina.</p>
+        <div className="grid gap-2">
+          {players.filter(p=>p.hp>0).map(p=>{
+            const inf = hasCondition(p.conditions,'infected');
+            const ble = hasCondition(p.conditions,'bleeding');
+            const stn = hasCondition(p.conditions,'stunned');
+            return (
+              <button
+                key={p.id}
+                onClick={()=>onPick(p.id)}
+                className="w-full text-left p-3 rounded-xl border border-white/10 hover:bg-white/5"
+              >
+                <div className="font-medium">{p.name}</div>
+                <div className="text-xs opacity-80">
+                  PV: {p.hp}
+                  {" · "}
+                  {inf && <span className="text-emerald-300">infectado</span>}
+                  {ble && <span className="text-red-300">{inf?" · ":""}sangrando</span>}
+                  {stn && <span className="text-zinc-300">{(inf||ble)?" · ":""}aturdido</span>}
+                  {(!inf && !ble && !stn) && <span>sin estados</span>}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex justify-end mt-3">
+          <button className="px-3 py-2 rounded-xl border border-white/15 hover:bg-white/5" onClick={onClose}>Cerrar</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data/combatPhrases.ts
+++ b/src/data/combatPhrases.ts
@@ -270,3 +270,44 @@ export const FLEE_LINES = [
   "Con una voltereta, ${P} cae fuera del alcance.",
   "${P} desaparece detrás de un camión volcado.",
 ];
+
+// === Contraataques de enemigos (20 variantes) ===
+export type CounterVars = { A: string; P: string; D?: number; EFF?: string }; // A=Attacker(enemigo), P=Player
+export function renderCounter(tpl: string, v: CounterVars){
+  return tpl
+    .replaceAll("${A}", v.A)
+    .replaceAll("${P}", v.P)
+    .replaceAll("${D}", v.D != null ? String(v.D) : "")
+    .replaceAll("${EFF}", v.EFF ?? "");
+}
+
+export const ENEMY_COUNTER_20: string[] = [
+  "${A} contraataca por instinto y ha ${EFF} a ${P} (−${D} PV).",
+  "Aprovechando el fallo, ${A} se abalanza y ${EFF} a ${P} (−${D}).",
+  "${A} responde al hueco y ${EFF} a ${P} (−${D}).",
+  "Un golpe rápido de ${A} ${EFF} a ${P} (−${D}).",
+  "${A} gira la guardia y ${EFF} a ${P} (−${D}).",
+  "Movimiento seco: ${A} ${EFF} a ${P} (−${D}).",
+  "Contra embestida: ${A} ${EFF} a ${P} (−${D}).",
+  "Lectura perfecta de ${A}: ${EFF} a ${P} (−${D}).",
+  "Cuando ${P} falla, ${A} castiga y ${EFF} (−${D}).",
+  "Reflejos fríos: ${A} ${EFF} a ${P} (−${D}).",
+  "${A} encuentra un ángulo y ${EFF} a ${P} (−${D}).",
+  "Finta brutal de ${A} ${EFF} a ${P} (−${D}).",
+  "Golpe al descuido: ${A} ${EFF} a ${P} (−${D}).",
+  "Paso lateral de ${A} y ${EFF} a ${P} (−${D}).",
+  "${A} no perdona: ${EFF} a ${P} (−${D}).",
+  "Zarpazo de ${A}: ${EFF} a ${P} (−${D}).",
+  "Reacción inmediata: ${A} ${EFF} a ${P} (−${D}).",
+  "Bloqueo y respuesta: ${A} ${EFF} a ${P} (−${D}).",
+  "Contraataque limpio: ${A} ${EFF} a ${P} (−${D}).",
+  "Oportunidad cobrada: ${A} ${EFF} a ${P} (−${D}).",
+];
+
+// Efectos legibles
+export function counterEffectText(kind: "bleeding"|"stunned"|"infected"|"hit"){
+  if (kind === "bleeding") return "dejado sangrando";
+  if (kind === "stunned")  return "aturdido";
+  if (kind === "infected") return "infectado";
+  return "golpeado";
+}


### PR DESCRIPTION
## Summary
- add 20 enemy counterattack phrases and helpers
- allow players to heal allies via new modal
- log counterattacks with effects and damage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b939cffbc88325b7ce5a38291923b1