### PR TITLE
Improve combat summary and survivor status tags

### DIFF
--- a/src/components/overlays/CombatEndSummary.tsx
+++ b/src/components/overlays/CombatEndSummary.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 type Props = {
   open: boolean;
-  lines: string[];
-  onFinish: () => void;
+  lines: string[];            // líneas del resumen (una por ítem)
+  onFinish: () => void;       // al terminar y pulsar el botón
 };
 
 export default function CombatEndSummary({ open, lines, onFinish }: Props) {
@@ -18,13 +18,13 @@ export default function CombatEndSummary({ open, lines, onFinish }: Props) {
     setShown("");
     setTyping(true);
     let i = 0;
-    const step = () => {
+    const tick = () => {
       if (i >= current.length) { setTyping(false); return; }
       setShown(prev => prev + current[i]);
       i++;
-      setTimeout(step, 12);
+      setTimeout(tick, 12);
     };
-    step();
+    tick();
   }, [open, idx, current]);
 
   useEffect(() => {
@@ -35,18 +35,18 @@ export default function CombatEndSummary({ open, lines, onFinish }: Props) {
         setTyping(false);
         setShown(current);
       } else {
-        if (idx < lines.length - 1) {
-          setIdx(x => x + 1);
-        } else {
-          onFinish();
-        }
+        if (idx < lines.length - 1) setIdx(x => x + 1);
+        // Si ya no hay más líneas, no cerramos: mostramos botón "Continuar"
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, typing, idx, lines.length, current, onFinish]);
+  }, [open, typing, idx, lines.length, current]);
 
   if (!open) return null;
+
+  const finished = !typing && idx >= lines.length - 1;
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
@@ -55,10 +55,23 @@ export default function CombatEndSummary({ open, lines, onFinish }: Props) {
         <div className="text-sm whitespace-pre-wrap font-mono bg-black/30 rounded-lg p-3 min-h-[120px] border border-white/5">
           {shown}
         </div>
-        <div className="mt-3 text-xs text-center opacity-80 animate-pulse-slow">
-          Presiona Enter para continuar
-        </div>
+        {!finished && (
+          <div className="mt-3 text-xs text-center opacity-80 animate-pulse">
+            Presiona Enter para continuar
+          </div>
+        )}
+        {finished && (
+          <div className="mt-4 flex justify-end">
+            <button
+              className="px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500"
+              onClick={onFinish}
+            >
+              Continuar
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- Tidy survivor cards with badges under the name and "Fuera de combate" when HP hits zero
- Add combat end overlay with skipable lines and final Continue button
- Compute combat battle summary and lock controls when enemies are cleared

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b941c6ce5883259451168cdd848e11