### PR TITLE
Añade cajas de munición y recarga de armas

### DIFF
--- a/src/types/items.ts
+++ b/src/types/items.ts
@@ -1,0 +1,8 @@
+export type AmmoBox = {
+  id: string;
+  name: string;
+  type: "ammo_box";
+  bullets: number;
+};
+
+export type BackpackItem = AmmoBox | { id: string; name: string; type: string; [key: string]: any };


### PR DESCRIPTION
## Summary
- Define `AmmoBox` item type and integrate player backpack helpers for handling ammunition boxes
- Allow exploration and enemy deaths to drop ammo boxes
- Show ammo counts and add a reload button in the player details panel

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b946ca17e48325923bd3bf64fab96d