### PR TITLE
feat: guard app against runtime errors and refine pause flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -452,15 +452,11 @@ export default function App(){
   // Reloj del día
   useEffect(()=>{
     if(state!=="playing") return;
-    let id: number|undefined;
-    id = window.setInterval(()=>{
+    const id = window.setInterval(()=>{
       if(!timeRunning) return;
-      setClockMs((ms)=>{
+      setClockMs(ms=>{
         const next = ms - 1000;
-        if(next <= 0){
-          endOfDay('timer');
-          return DAY_LENGTH_MS;
-        }
+        if(next <= 0){ endOfDay('timer'); return DAY_LENGTH_MS; }
         return next;
       });
     }, 1000);
@@ -1688,6 +1684,10 @@ function advanceTurn() {
     setClockMs(ms=> Math.max(0, ms - seconds*1000));
   }
 
+  useEffect(()=>{
+    console.debug("[state] state:", state, "timeRunning:", timeRunning, "day:", day);
+  }, [state, timeRunning, day]);
+
   // ——— Inventario ———
   const [stash, setStash] = useState<string[]>(["Pistola","Botiquín","Linterna","Cuerda","Chatarra"]);
 
@@ -1766,7 +1766,15 @@ function advanceTurn() {
           <p className="mt-3 text-neutral-300">Sistema ligero con mazos, tiempo real y supervivencia.</p>
           <div className="mt-10 space-x-3">
             <button className="btn btn-red text-white" onClick={start}>Comenzar</button>
-            <button className="btn btn-ghost" onClick={()=>{setState("playing"); setTimeRunning(false);}}>Entrar en Pausa</button>
+            <button
+              className="btn btn-ghost"
+              onClick={()=>{
+                setTimeRunning(false);
+                setState("paused");
+              }}
+            >
+              Entrar en Pausa
+            </button>
           </div>
           <div className="mt-16 text-neutral-400 text-sm">
             <p>Consejo: las acciones consumen tiempo del día. La noche es peligrosa.</p>
@@ -1908,7 +1916,10 @@ function advanceTurn() {
         <div className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50">
           <div className="p-8 rounded-2xl border border-neutral-700 bg-neutral-900 max-w-md w-full space-y-4">
             <h2 className="text-2xl font-bold text-red-400">Pausado</h2>
-            <button className="btn btn-red text-white w-full" onClick={()=>setState("playing")}>Continuar</button>
+            <button className="btn btn-red text-white w-full" onClick={()=>{
+              setState("playing");
+              // reanudar queda en control del botón de play/pausa del HUD, no forzamos timeRunning
+            }}>Continuar</button>
           </div>
         </div>
       )}

--- a/src/components/util/SafeBoundary.tsx
+++ b/src/components/util/SafeBoundary.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+type State = { hasError: boolean; message?: string };
+
+export default class SafeBoundary extends React.Component<React.PropsWithChildren, State> {
+  constructor(p:any){ super(p); this.state = { hasError:false, message:"" }; }
+  static getDerivedStateFromError(err:any){ return { hasError:true, message:String(err?.message ?? err) }; }
+  componentDidCatch(err:any, info:any){ console.error("[SafeBoundary] error:", err, info); }
+  render(){
+    if(this.state.hasError){
+      return (
+        <div className="min-h-screen bg-black text-white p-4">
+          <div className="max-w-2xl mx-auto bg-zinc-900/90 border border-white/10 rounded-2xl p-6">
+            <h1 className="text-lg font-bold mb-2">Algo se rompió…</h1>
+            <p className="text-sm opacity-80 mb-3">Capturamos el error para que el juego no quede en negro.</p>
+            <pre className="text-xs bg-black/40 p-3 rounded border border-white/10 overflow-auto">{this.state.message}</pre>
+            <button className="mt-4 px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500" onClick={()=>location.reload()}>Recargar</button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,13 @@ import React from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './styles.css'
+import SafeBoundary from './components/util/SafeBoundary'
 
 const root = createRoot(document.getElementById('root')!)
-root.render(<React.StrictMode><App /></React.StrictMode>)
+root.render(
+  <React.StrictMode>
+    <SafeBoundary>
+      <App />
+    </SafeBoundary>
+  </React.StrictMode>
+)


### PR DESCRIPTION
## Summary
- add SafeBoundary error boundary to prevent black screens
- wrap App in SafeBoundary and tighten pause/play controls
- log state transitions for diagnostics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b94bc3c430832594b36b08729db80a