### PR TITLE
Add safe weapon selector and import fixes

### DIFF
--- a/src/components/WeaponPicker.tsx
+++ b/src/components/WeaponPicker.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { findWeaponById } from "../data/weapons";
+import { getSelectedWeapon, getAmmoFor, isRangedWeapon } from "../systems/weapons";
 
 type WeaponPickerProps = {
   player: any;
   backpack: { id: string; name: string; type: "melee" | "ranged"; damage?: any }[];
   onSelect: (weaponId: string) => void;
-  ammoFor: (weaponId: string) => number;
 };
 
-export default function WeaponPicker({ player, backpack, onSelect, ammoFor }: WeaponPickerProps){
+export default function WeaponPicker({ player, backpack, onSelect }: WeaponPickerProps){
   const weapons = [
     { id: "fists", name: "Puños", type: "melee" as const, damage: { min: 1, max: 2 } },
     ...backpack.filter(it => it.type === "melee" || it.type === "ranged"),
@@ -27,7 +27,7 @@ export default function WeaponPicker({ player, backpack, onSelect, ammoFor }: We
     return { ...w, name: w.name || it.name, type: w.type || it.type, damage: { min, max } };
   });
 
-  const sel = player.selectedWeaponId || "fists";
+  const sel = getSelectedWeapon(player).id;
 
   return (
     <div className="mt-3">
@@ -35,9 +35,9 @@ export default function WeaponPicker({ player, backpack, onSelect, ammoFor }: We
       <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
         {weapons.map(w => {
           const selected = sel === w.id;
-          const isRanged = w.type === "ranged";
-          const ammo = isRanged ? ammoFor(w.id) : null;
-          const disabled = isRanged && (ammo ?? 0) <= 0;
+          const ranged = isRangedWeapon(w);
+          const ammo = ranged ? getAmmoFor(player, w.id) : null;
+          const disabled = ranged && (ammo ?? 0) <= 0;
           return (
             <button
               key={w.id}
@@ -53,7 +53,7 @@ export default function WeaponPicker({ player, backpack, onSelect, ammoFor }: We
                 Daño: {w?.damage ? `${w.damage.min ?? "?"}–${w.damage.max ?? "?"}` : "?"}
               </div>
               <div className="text-xs opacity-80">
-                Munición: {isRanged ? (ammo ?? 0) : "--"}
+                Munición: {ranged ? (ammo ?? 0) : "--"}
               </div>
             </button>
           );

--- a/src/systems/weapons.ts
+++ b/src/systems/weapons.ts
@@ -1,0 +1,49 @@
+import { findWeaponById } from "../data/weapons";
+
+// Pseudo-arma por defecto (puños), por si no hay selección válida.
+export const FISTS_WEAPON = {
+  id: "fists",
+  name: "Puños",
+  type: "melee",
+  damageMin: 1,
+  damageMax: 2,
+  damage: { times: 1, faces: 2, mod: 0 },
+};
+
+/**
+ * Devuelve el arma seleccionada para un jugador.
+ * - Si player.selectedWeaponId está definido y existe en el catálogo -> ese arma.
+ * - Si no, devuelve Puños.
+ * Nunca retorna undefined (evita crasheos de UI).
+ */
+export function getSelectedWeapon(player: any) {
+  try {
+    const selId = player?.selectedWeaponId;
+    if (selId) {
+      const w = findWeaponById(selId);
+      if (w) {
+        const times = w.damage?.times ?? 0;
+        const faces = w.damage?.faces ?? 0;
+        const mod = w.damage?.mod ?? 0;
+        return { ...w, damageMin: times + mod, damageMax: times * faces + mod };
+      }
+    }
+  } catch (_) {}
+  return FISTS_WEAPON;
+}
+
+/**
+ * Munición actual para un arma concreta del jugador.
+ * Si no existe estructura, devuelve 0.
+ */
+export function getAmmoFor(player: any, weaponId: string): number {
+  return Math.max(0, Number(player?.ammoByWeapon?.[weaponId] ?? 0));
+}
+
+/**
+ * Devuelve true si un arma es de fuego (por si tu UI lo necesita).
+ */
+export function isRangedWeapon(w: any): boolean {
+  return w?.type === "ranged" || w?.range === "ranged";
+}
+


### PR DESCRIPTION
## Summary
- add weapon helpers to safely resolve selected weapon, ammo, and range
- use safe weapon helpers across app and weapon picker to avoid undefined errors
- show current weapon info and ammo with new helpers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b94dd41b708325bb2d765014d767b2