### PR TITLE
feat: add global logger and replace pushLog

### DIFF
--- a/src/components/DeckUI.tsx
+++ b/src/components/DeckUI.tsx
@@ -9,18 +9,7 @@ import {
   isCombat,
 } from "@/lib/deck";
 import type { DeckBundle, ChoiceEffect } from "@/lib/deck";
-
-type LogType =
-  | "info"
-  | "combat"
-  | "danger"
-  | "success"
-  | "story"
-  | "death"
-  | "level"
-  | "resource"
-  | "moral"
-  | "system";
+import { gameLog } from "@/utils/logger";
 
 type Props = {
   storyDeck: DeckBundle;
@@ -29,8 +18,6 @@ type Props = {
   onChoose: (effect: ChoiceEffect, sourceCard: AnyCard) => void;
   /** Avanza el turno cuando el jugador decide “pasar” */
   onPassTurn: () => void;
-  /** (Opcional) Para registrar mensajes en tu bitácora */
-  onLog?: (msg: string, type?: LogType) => void;
 };
 
 export default function DeckUI({
@@ -38,7 +25,6 @@ export default function DeckUI({
   combatDeck,
   onChoose,
   onPassTurn,
-  onLog,
 }: Props) {
   const [current, setCurrent] = useState<AnyCard | null>(null);
   // “tick” para forzar rerender cuando mutamos el estado del mazo
@@ -68,19 +54,15 @@ export default function DeckUI({
     const card = drawOne(deck);
     bump();
     if (!card) {
-      onLog?.(
+      gameLog(
         kind === "story"
           ? "No quedan cartas de decisión. Reintegra o baraja."
-          : "No quedan cartas de combate. Reintegra o baraja.",
-        kind === "story" ? "story" : "combat"
+          : "No quedan cartas de combate. Reintegra o baraja."
       );
       return;
     }
     setCurrent(card);
-    onLog?.(
-      `Robas carta: ${card.title}`,
-      kind === "story" ? "story" : "combat"
-    );
+    gameLog(`Robas carta: ${card.title}`);
   }
 
   function discardCurrent() {
@@ -107,9 +89,8 @@ export default function DeckUI({
     const deck = kind === "story" ? storyDeck : combatDeck;
     shuffleDrawPile(deck);
     bump();
-    onLog?.(
-      kind === "story" ? "Barajas el mazo de decisión." : "Barajas el mazo de combate.",
-      "system"
+    gameLog(
+      kind === "story" ? "Barajas el mazo de decisión." : "Barajas el mazo de combate."
     );
   }
 
@@ -117,11 +98,10 @@ export default function DeckUI({
     const deck = kind === "story" ? storyDeck : combatDeck;
     reintegrateDiscards(deck);
     bump();
-    onLog?.(
+    gameLog(
       kind === "story"
         ? "Reintegras descartes al mazo de decisión."
-        : "Reintegras descartes al mazo de combate.",
-      "system"
+        : "Reintegras descartes al mazo de combate."
     );
   }
 

--- a/src/systems/ammo.ts
+++ b/src/systems/ammo.ts
@@ -1,5 +1,6 @@
 // src/systems/ammo.ts
 import { getSelectedWeapon, isRangedWeapon } from "./weapons";
+import { gameLog } from "../utils/logger";
 
 /** Detecta si un item del inventario es una caja de munición. */
 export function isAmmoBox(item: any): boolean {
@@ -67,22 +68,26 @@ export function spendAmmo(player: any, weaponId: string, amount = 1) {
 }
 
 /** Recarga el arma seleccionada del jugador consumiendo UNA caja del inventario. */
-export function reloadSelectedWeapon(player: any, pushLog?: (s: string) => void) {
+export function reloadSelectedWeapon(player: any, onBattleLog?: (s: string) => void) {
   if (!player) return player;
   const w = getSelectedWeapon(player);
+  const log = (msg: string) => {
+    onBattleLog?.(msg);
+    gameLog(msg);
+  };
   if (!isRangedWeapon(w)) {
-    pushLog?.(`${player.name} intenta recargar, pero ${w.name} no usa munición.`);
+    log(`${player.name} intenta recargar, pero ${w.name} no usa munición.`);
     return player;
   }
   const { bullets, newInventory } = consumeOneAmmoBox(player.inventory);
   if (bullets <= 0) {
-    pushLog?.(`${player.name} no tiene cajas de munición disponibles.`);
+    log(`${player.name} no tiene cajas de munición disponibles.`);
     return player;
   }
   const cur = getLoadedAmmo(player, w.id);
   const nextCount = cur + bullets;
   const updated = setLoadedAmmo({ ...player, inventory: newInventory }, w.id, nextCount);
-  pushLog?.(`${player.name} recarga ${w.name}: +${bullets} balas (munición: ${nextCount}).`);
+  log(`${player.name} recarga ${w.name}: +${bullets} balas (munición: ${nextCount}).`);
   return updated;
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,22 @@
+export type LogFn = (msg: string) => void;
+
+let currentLogger: LogFn = () => {};
+/**
+ * Registra la función que empuja logs al estado de la app.
+ * Se puede llamar múltiples veces; siempre usaremos la última.
+ */
+export function registerLogger(fn: LogFn) {
+  currentLogger = fn;
+}
+
+/**
+ * Publica un log de juego de forma segura.
+ * Nunca lanza, aunque no haya logger registrado aún.
+ */
+export function gameLog(message: string) {
+  try {
+    currentLogger(message);
+  } catch {
+    // no-op para no romper el runtime
+  }
+}


### PR DESCRIPTION
## Summary
- add global logger utility with register and safe gameLog
- register logger in App and swap pushLog usages across project
- remove onLog props and centralize logging

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b9b505ffe483258167003277db34ff