### PR TITLE
feat: add container exploration events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,9 @@ import {
   applyEndOfTurnConditions,
   cureCondition,
 } from "./systems/status";
+import ContainersSection from "./components/ContainersSection";
+import { pickRandomContainer, openContainer } from "./systems/containers";
+import type { GameState as GameWorldState, ContainersState } from "./types/game";
 
 
 // === Botiquín helpers ===
@@ -291,7 +294,18 @@ export default function App(){
   const [morale, setMorale] = useState(60);
   const [threat, setThreat] = useState(10);
   const [resources, setResources] = useState<Resources>({ food: 15, water: 15, medicine: 6, fuel: 10, ammo: 30, materials: 12 });
+  const [containersState, setContainersState] = useState<ContainersState>({
+    openedIdsByDay: {1:new Set(),2:new Set(),3:new Set()},
+    lastOpenedWasContainer: false
+  });
   const [camp, setCamp] = useState<Camp>({ defense: 10, comfort: 10 });
+
+  const worldState: GameWorldState = { resources, containersState };
+  const setWorldState = (updater:(s:GameWorldState)=>GameWorldState) => {
+    const next = updater({ resources, containersState });
+    if (next.resources !== resources) setResources(next.resources);
+    if (next.containersState !== containersState) setContainersState(next.containersState);
+  };
 
   const [players, setPlayers] = useState<Player[]>([
     mkPlayer("Sarah", "Médica"),
@@ -1501,6 +1515,7 @@ function advanceTurn() {
     } else {
       pushLog("Esta nota no contiene pista accionable.");
     }
+    setContainersState(cs=>({ ...cs, lastOpenedWasContainer:false }));
   }
 
   useEffect(() => {
@@ -1552,13 +1567,35 @@ function advanceTurn() {
       pushLog(`🔎 ${card.title}`);
       pushLog(card.text);
       discoverRandomNote(0.25);
+      setContainersState(cs=>({ ...cs, lastOpenedWasContainer:false }));
       return;
     }
 
     timePenalty(60 + Math.floor(Math.random()*60));
+    if(!containersState.lastOpenedWasContainer){
+      const rollC = Math.random();
+      if(rollC < 0.40){
+        const c = pickRandomContainer(day, { resources, containersState });
+        if(c){
+          gameLog(`🧭 Encontraste un contenedor: ${c.name} (${c.place})`);
+          openContainer(day, c.id, { resources, containersState });
+          setResources(r=>({ ...r }));
+          setContainersState(s=>({ ...s }));
+          setExplorationActive(false);
+          if (!isEnemyPhaseRef.current && activePlayerIdRef.current) {
+            setActedThisRound(m => ({ ...m, [activePlayerIdRef.current as string]: true }));
+          }
+          finalizeTurnWithEndConditions(() => {
+            advanceTurn();
+          });
+          return;
+        }
+      }
+    }
 
     const roll = Math.random();
     if(roll < 0.2){
+      setContainersState(cs=>({ ...cs, lastOpenedWasContainer:false }));
       const count = 1 + Math.floor(Math.random()*3);
       spawnEnemies(count);
       setBattleStats({ byPlayer: {}, lootNames: [] });
@@ -1639,6 +1676,7 @@ function advanceTurn() {
     }
 
     pushLog(`${ev.text} — Recompensa obtenida.`);
+    setContainersState(cs=>({ ...cs, lastOpenedWasContainer:false }));
     setExplorationActive(false);
     if (!isEnemyPhaseRef.current && activePlayerIdRef.current) {
       setActedThisRound(m => ({ ...m, [activePlayerIdRef.current as string]: true }));
@@ -2516,6 +2554,8 @@ function InventoryPanel({stash, players, giveItem, takeItem, foundNotes, followN
           </div>
         )}
       </div>
+
+      <ContainersSection day={day} state={worldState} setState={setWorldState} />
 
       <div className="mt-6 bg-gradient-to-br from-neutral-900 to-black border border-neutral-800 rounded-2xl p-6">
         <h3 className="text-xl font-bold mb-4">🗒️ Notas encontradas</h3>

--- a/src/components/ContainersSection.tsx
+++ b/src/components/ContainersSection.tsx
@@ -1,0 +1,49 @@
+import React, { useMemo } from 'react';
+import { getAvailableContainers, openContainer } from '../systems/containers';
+import { GameState } from '../types/game';
+import { gameLog } from '../utils/logger';
+
+type Props = {
+  day: number;
+  state: GameState;
+  setState: (updater:(s:GameState)=>GameState) => void;
+};
+
+export default function ContainersSection({ day, state, setState }: Props) {
+  const list = useMemo(() => getAvailableContainers(day, state), [day, state]);
+
+  if (!list.length) return (
+    <div className="mt-2 text-sm opacity-70">Sin contenedores disponibles por ahora.</div>
+  );
+
+  return (
+    <div className="mt-4">
+      <h3 className="text-lg font-semibold">Contenedores</h3>
+      <ul className="mt-2 space-y-2">
+        {list.map(c => (
+          <li key={c.id} className="flex items-center justify-between rounded-xl border p-3">
+            <div>
+              <div className="font-medium">{c.name}</div>
+              <div className="text-xs opacity-70">{c.place}</div>
+            </div>
+            <button
+              className="px-3 py-1 rounded-lg bg-emerald-600 text-white hover:opacity-90 animate-pulse"
+              onClick={()=>{
+                setState(prev=>{
+                  const next = { ...prev };
+                  const gained = openContainer(day, c.id, next);
+                  if (gained <= 0) {
+                    gameLog('No se pudo abrir el contenedor.');
+                  }
+                  return next;
+                });
+              }}
+            >
+              Abrir
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/data/containers.index.ts
+++ b/src/data/containers.index.ts
@@ -1,0 +1,3 @@
+export { containersDay1 } from './days/day1/containers.day1';
+export { containersDay2 } from './days/day2/containers.day2';
+export { containersDay3 } from './days/day3/containers.day3';

--- a/src/data/days/day1/containers.day1.ts
+++ b/src/data/days/day1/containers.day1.ts
@@ -1,0 +1,16 @@
+import { ExplorationContainer } from '../../../types/exploration';
+
+export const containersDay1: ExplorationContainer[] = [
+  { id: 'D1-C01', kind:'container', name:'Estante polvoriento', place:'Almacén de barrio', rarity:'common', ammoMin:2, ammoMax:5, description:'Cajas pequeñas entre polvo.' },
+  { id: 'D1-C02', kind:'container', name:'Caja reforzada', place:'Pasillo trasero de supermercado', rarity:'rare', ammoMin:4, ammoMax:8 },
+  { id: 'D1-C03', kind:'container', name:'Caja de herramientas', place:'Taller mecánico', rarity:'common', ammoMin:2, ammoMax:6 },
+  { id: 'D1-C04', kind:'container', name:'Casillero oxidado', place:'Terminal de buses', rarity:'common', ammoMin:1, ammoMax:4 },
+  { id: 'D1-C05', kind:'container', name:'Caja de seguridad', place:'Oficina abandonada', rarity:'rare', ammoMin:5, ammoMax:9 },
+  { id: 'D1-C06', kind:'container', name:'Guantera de automóvil', place:'Avenida principal', rarity:'common', ammoMin:1, ammoMax:3 },
+  { id: 'D1-C07', kind:'container', name:'Contenedor de envío', place:'Patio de carga', rarity:'rare', ammoMin:3, ammoMax:7 },
+  { id: 'D1-C08', kind:'container', name:'Locker del personal', place:'Almacén minorista', rarity:'common', ammoMin:2, ammoMax:5 },
+  { id: 'D1-C09', kind:'container', name:'Caja de metal', place:'Pasillo de mantenimiento', rarity:'common', ammoMin:2, ammoMax:4 },
+  { id: 'D1-C10', kind:'container', name:'Cajón oculto', place:'Bodega de restaurant', rarity:'rare', ammoMin:4, ammoMax:7 },
+  { id: 'D1-C11', kind:'container', name:'Estantería reforzada', place:'Ferretería', rarity:'common', ammoMin:3, ammoMax:6 },
+  { id: 'D1-C12', kind:'container', name:'Baúl con candado', place:'Casa abandonada', rarity:'rare', ammoMin:4, ammoMax:8 },
+];

--- a/src/data/days/day2/containers.day2.ts
+++ b/src/data/days/day2/containers.day2.ts
@@ -1,0 +1,16 @@
+import { ExplorationContainer } from '../../../types/exploration';
+
+export const containersDay2: ExplorationContainer[] = [
+  { id: 'D2-C01', kind:'container', name:'Caja militar', place:'Puesto de control', rarity:'military', ammoMin:6, ammoMax:12 },
+  { id: 'D2-C02', kind:'container', name:'Armero portátil', place:'Subsuelo de comisaría', rarity:'military', ammoMin:7, ammoMax:13 },
+  { id: 'D2-C03', kind:'container', name:'Estante trasero', place:'Almacén mayorista', rarity:'common', ammoMin:3, ammoMax:6 },
+  { id: 'D2-C04', kind:'container', name:'Caja ignífuga', place:'Planta eléctrica', rarity:'rare', ammoMin:5, ammoMax:9 },
+  { id: 'D2-C05', kind:'container', name:'Caja de herramientas pesada', place:'Taller ferroviario', rarity:'common', ammoMin:3, ammoMax:7 },
+  { id: 'D2-C06', kind:'container', name:'Armario de seguridad', place:'Hospital viejo', rarity:'rare', ammoMin:4, ammoMax:8 },
+  { id: 'D2-C07', kind:'container', name:'Contenedor refrigerado', place:'Centro logístico', rarity:'rare', ammoMin:4, ammoMax:9 },
+  { id: 'D2-C08', kind:'container', name:'Caja reforzada', place:'Hangar de buses', rarity:'common', ammoMin:3, ammoMax:6 },
+  { id: 'D2-C09', kind:'container', name:'Estante de repuestos', place:'Taller de bicicletas', rarity:'common', ammoMin:2, ammoMax:5 },
+  { id: 'D2-C10', kind:'container', name:'Caja de seguridad mediana', place:'Sucursal bancaria', rarity:'rare', ammoMin:6, ammoMax:10 },
+  { id: 'D2-C11', kind:'container', name:'Locker numerado', place:'Centro deportivo', rarity:'common', ammoMin:2, ammoMax:4 },
+  { id: 'D2-C12', kind:'container', name:'Trinchera de suministros', place:'Perímetro militar', rarity:'military', ammoMin:8, ammoMax:14 },
+];

--- a/src/data/days/day3/containers.day3.ts
+++ b/src/data/days/day3/containers.day3.ts
@@ -1,0 +1,16 @@
+import { ExplorationContainer } from '../../../types/exploration';
+
+export const containersDay3: ExplorationContainer[] = [
+  { id: 'D3-C01', kind:'container', name:'Caja fuerte averiada', place:'Edificio municipal', rarity:'rare', ammoMin:6, ammoMax:11 },
+  { id: 'D3-C02', kind:'container', name:'Estante oculto', place:'Biblioteca antigua', rarity:'common', ammoMin:3, ammoMax:6 },
+  { id: 'D3-C03', kind:'container', name:'Armero mural', place:'Cuartel abandonado', rarity:'military', ammoMin:8, ammoMax:15 },
+  { id: 'D3-C04', kind:'container', name:'Contenedor blindado', place:'Terminal de carga', rarity:'military', ammoMin:7, ammoMax:13 },
+  { id: 'D3-C05', kind:'container', name:'Caja de herramientas premium', place:'Taller aeronáutico', rarity:'rare', ammoMin:5, ammoMax:9 },
+  { id: 'D3-C06', kind:'container', name:'Locker de supervisión', place:'Refinería', rarity:'common', ammoMin:2, ammoMax:5 },
+  { id: 'D3-C07', kind:'container', name:'Caja sellada', place:'Almacén frigorífico', rarity:'rare', ammoMin:5, ammoMax:10 },
+  { id: 'D3-C08', kind:'container', name:'Depósito militar', place:'Base perimetral', rarity:'military', ammoMin:9, ammoMax:16 },
+  { id: 'D3-C09', kind:'container', name:'Cofre metálico', place:'Teatro antiguo', rarity:'common', ammoMin:3, ammoMax:6 },
+  { id: 'D3-C10', kind:'container', name:'Caja ignífuga XL', place:'Laboratorio', rarity:'rare', ammoMin:6, ammoMax:12 },
+  { id: 'D3-C11', kind:'container', name:'Casillero blindado', place:'Estación subterránea', rarity:'military', ammoMin:7, ammoMax:14 },
+  { id: 'D3-C12', kind:'container', name:'Caja reforzada industrial', place:'Astillero', rarity:'rare', ammoMin:6, ammoMax:11 },
+];

--- a/src/systems/containers.ts
+++ b/src/systems/containers.ts
@@ -1,0 +1,61 @@
+import { containersDay1, containersDay2, containersDay3 } from '../data/containers.index';
+import { ExplorationContainer } from '../types/exploration';
+import { GameState } from '../types/game';
+import { gameLog } from '../utils/logger';
+
+export function getContainersForDay(day:number): ExplorationContainer[] {
+  if (day === 1) return containersDay1;
+  if (day === 2) return containersDay2;
+  return containersDay3;
+}
+
+export function getAvailableContainers(day:number, state:GameState): ExplorationContainer[] {
+  const opened = state.containersState?.openedIdsByDay?.[day] ?? new Set<string>();
+  return getContainersForDay(day).filter(c => !opened.has(c.id));
+}
+
+export function pickRandomContainer(day:number, state:GameState): ExplorationContainer | null {
+  const pool = getAvailableContainers(day, state);
+  if (!pool.length) return null;
+  const idx = Math.floor(Math.random() * pool.length);
+  return pool[idx];
+}
+
+export function rarityAmmoBoost(rarity: 'common'|'rare'|'military'): number {
+  if (rarity === 'military') return 1.25;
+  if (rarity === 'rare') return 1.1;
+  return 1.0;
+}
+
+export function openContainer(day:number, containerId:string, state:GameState): number {
+  if (!state.containersState) throw new Error('containersState no inicializado');
+  if (state.containersState.lastOpenedWasContainer) {
+    gameLog('⛔ No puedes abrir dos contenedores seguidos. Realiza otra acción y vuelve a intentar.');
+    return 0;
+  }
+  const pool = getContainersForDay(day);
+  const c = pool.find(x => x.id === containerId);
+  if (!c) return 0;
+
+  const openedSet = state.containersState.openedIdsByDay[day] ?? new Set<string>();
+  if (openedSet.has(c.id)) {
+    gameLog('⚠️ Ese contenedor ya fue abierto.');
+    return 0;
+  }
+
+  const boost = rarityAmmoBoost(c.rarity);
+  const min = Math.max(0, Math.floor(c.ammoMin * boost));
+  const max = Math.max(min, Math.floor(c.ammoMax * boost));
+  const amount = Math.floor(Math.random() * (max - min + 1)) + min;
+
+  state.resources = state.resources ?? {} as any;
+  const prev = (state.resources.ammo ?? 0);
+  state.resources.ammo = prev + amount;
+
+  openedSet.add(c.id);
+  state.containersState.openedIdsByDay[day] = openedSet;
+  state.containersState.lastOpenedWasContainer = true;
+
+  gameLog(`🔓 Abriste ${c.name} en ${c.place}. Munición obtenida: +${amount}.`);
+  return amount;
+}

--- a/src/types/exploration.ts
+++ b/src/types/exploration.ts
@@ -1,0 +1,12 @@
+export type ContainerRarity = 'common' | 'rare' | 'military';
+
+export interface ExplorationContainer {
+  id: string;               // único por día
+  kind: 'container';
+  name: string;             // "Caja reforzada", "Almacén", etc
+  place: string;            // "Depósito del barrio", "Taller", etc
+  description?: string;
+  rarity: ContainerRarity;  // afecta rango de loot
+  ammoMin: number;          // munición mínima al abrir
+  ammoMax: number;          // munición máxima al abrir
+}

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,9 @@
+export interface ContainersState {
+  openedIdsByDay: Record<number, Set<string>>;
+  lastOpenedWasContainer: boolean;
+}
+
+export interface GameState {
+  resources: { ammo: number; [k: string]: any };
+  containersState: ContainersState;
+}


### PR DESCRIPTION
## Summary
- add new exploration container type and day-specific data
- implement container system with anti-repeat logic and ammo rewards
- integrate Containers section and random container events

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b9c1f3d5d88325bac679919428faf8