### PR TITLE
Centralize day lookup via state utility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ import {
 } from "./systems/status";
 import ContainersSection from "./components/ContainersSection";
 import { pickRandomContainer, openContainer } from "./systems/containers";
+import { getCurrentDay } from "./utils/day";
 import type { GameState as GameWorldState, ContainersState } from "./types/game";
 
 
@@ -1575,10 +1576,11 @@ function advanceTurn() {
     if(!containersState.lastOpenedWasContainer){
       const rollC = Math.random();
       if(rollC < 0.40){
-        const c = pickRandomContainer(day, { resources, containersState });
+        const currentDay = getCurrentDay({ day });
+        const c = pickRandomContainer(currentDay, { resources, containersState });
         if(c){
           gameLog(`🧭 Encontraste un contenedor: ${c.name} (${c.place})`);
-          openContainer(day, c.id, { resources, containersState });
+          openContainer(currentDay, c.id, { resources, containersState });
           setResources(r=>({ ...r }));
           setContainersState(s=>({ ...s }));
           setExplorationActive(false);

--- a/src/components/ContainersSection.tsx
+++ b/src/components/ContainersSection.tsx
@@ -2,15 +2,17 @@ import React, { useMemo } from 'react';
 import { getAvailableContainers, openContainer } from '../systems/containers';
 import { GameState } from '../types/game';
 import { gameLog } from '../utils/logger';
+import { getCurrentDay } from '../utils/day';
 
 type Props = {
-  day: number;
+  day?: number;
   state: GameState;
   setState: (updater:(s:GameState)=>GameState) => void;
 };
 
 export default function ContainersSection({ day, state, setState }: Props) {
-  const list = useMemo(() => getAvailableContainers(day, state), [day, state]);
+  const currentDay = typeof day === 'number' ? day : getCurrentDay(state);
+  const list = useMemo(() => getAvailableContainers(currentDay, state), [currentDay, state]);
 
   if (!list.length) return (
     <div className="mt-2 text-sm opacity-70">Sin contenedores disponibles por ahora.</div>
@@ -31,7 +33,7 @@ export default function ContainersSection({ day, state, setState }: Props) {
               onClick={()=>{
                 setState(prev=>{
                   const next = { ...prev };
-                  const gained = openContainer(day, c.id, next);
+                  const gained = openContainer(currentDay, c.id, next);
                   if (gained <= 0) {
                     gameLog('No se pudo abrir el contenedor.');
                   }

--- a/src/utils/day.ts
+++ b/src/utils/day.ts
@@ -1,0 +1,10 @@
+export function getCurrentDay(state: any): number {
+  const cand =
+    state?.currentDay ??
+    state?.day ??
+    state?.time?.day ??
+    state?.timeline?.day ??
+    1;
+  const n = Number(cand);
+  return Number.isFinite(n) ? n : 1;
+}


### PR DESCRIPTION
## Summary
- add `getCurrentDay` util to safely read current day from game state
- use `getCurrentDay` in `ContainersSection` and exploration container logic to avoid undefined day references

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b9cc5da9908325bc7c4395d9afe8a1