### PR TITLE
fix: add safe world state access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,7 @@ import ContainersSection from "./components/ContainersSection";
 import { pickRandomContainer, openContainer } from "./systems/containers";
 import { getCurrentDay } from "./utils/day";
 import type { GameState as GameWorldState, ContainersState } from "./types/game";
-import { bindWorldRef } from "./state/world";
+import { setWorldRef } from "./state/world";
 
 
 // === Botiquín helpers ===
@@ -310,9 +310,10 @@ export default function App(){
     if (next.containersState !== containersState) setContainersState(next.containersState);
   };
 
-  useEffect(() => {
-    bindWorldRef(worldState);
-  }, [worldState]);
+    useEffect(() => {
+      setWorldRef(worldState);
+      (globalThis as any).worldState = worldState;
+    }, [worldState]);
 
   const [players, setPlayers] = useState<Player[]>([
     mkPlayer("Sarah", "Médica"),

--- a/src/global/installWorldVar.ts
+++ b/src/global/installWorldVar.ts
@@ -1,0 +1,21 @@
+// src/global/installWorldVar.ts
+// 1) Tipado para TS (no afecta runtime)
+declare global {
+  // eslint-disable-next-line no-var
+  var worldState: any;
+}
+export {};
+
+// 2) Enlazar propiedad en globalThis
+const g: any = globalThis as any;
+g.worldState = g.worldState ?? {};
+
+// 3) Definir la variable global real `worldState` (NO solo propiedad)
+//    Usamos Function para ejecutar en el ámbito global (no de módulo).
+try {
+  // Crea/reescribe la variable global 'worldState' y la vincula a globalThis.worldState
+  // eslint-disable-next-line no-new-func
+  new Function("g", "var worldState = g.worldState; g.worldState = worldState;")(g);
+} catch {
+  // Si el entorno bloquea, al menos queda globalThis.worldState
+}

--- a/src/global/worldPolyfill.dev.ts
+++ b/src/global/worldPolyfill.dev.ts
@@ -1,8 +1,8 @@
-import { getWorld, bindWorldRef } from "../state/world";
+import { getWorld, setWorldRef } from "../state/world";
 // Exponer accesores sobre window/globalThis para depurar en consola:
 Object.defineProperty(globalThis as any, "worldState", {
   get() { return getWorld(); },
-  set(v) { bindWorldRef(v); },
+  set(v) { setWorldRef(v); },
   configurable: true
 });
 export {};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import "./global/installWorldVar";
 import './global/dayShim'
 
 import React from 'react'

--- a/src/state/world.ts
+++ b/src/state/world.ts
@@ -2,17 +2,19 @@ import type { GameState } from "../types/game";
 
 export type World = GameState;
 
-let _worldRef: World = {} as World;
+let WORLD_REF: World = {} as World;
+
 /** Vincula la referencia viva del estado del juego (la App la llama). */
-export function bindWorldRef(ref: World) {
-  _worldRef = ref ?? ({} as World);
+export function setWorldRef(ref: World) {
+  WORLD_REF = ref ?? ({} as World);
 }
+
 /** Obtiene el estado actual del juego, siempre definido. */
 export function getWorld(): World {
-  return _worldRef ?? ({} as World);
+  return WORLD_REF ?? ({} as World);
 }
+
 /** Atajo para mutaciones localizadas (si el proyecto usa mutación interna). */
 export function withWorld<T>(fn: (w: World) => T): T {
-  const w = getWorld();
-  return fn(w);
+  return fn(getWorld());
 }


### PR DESCRIPTION
## Summary
- avoid ReferenceError by installing global `worldState` variable first
- add central world store with `getWorld`/`setWorldRef`
- sync global reference and store from app root

## Testing
- `npm run build`
- `npm run dev`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9df3f74b083258c75e4556046f3ac