### PR TITLE
fix: provide global day helper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -288,6 +288,7 @@ export default function App(){
   // Estado base
   const [state, setState] = useState<GameState>("menu");
   const [day, setDay] = useState<number>(1);
+  React.useEffect(()=>{ (globalThis as any).__DAY = day; }, [day]);
   const [phase, setPhase] = useState<Phase>("dawn");
   const [clockMs, setClockMs] = useState<number>(DAY_LENGTH_MS);
   const [timeRunning, setTimeRunning] = useState(true);

--- a/src/utils/day.ts
+++ b/src/utils/day.ts
@@ -1,10 +1,6 @@
-export function getCurrentDay(state: any): number {
-  const cand =
-    state?.currentDay ??
-    state?.day ??
-    state?.time?.day ??
-    state?.timeline?.day ??
-    1;
-  const n = Number(cand);
-  return Number.isFinite(n) ? n : 1;
+export function getCurrentDay(state?: any): number {
+  const g: any = (typeof globalThis !== 'undefined' ? (globalThis as any) : {}) || {};
+  const cands = [state?.currentDay, state?.day, state?.time?.day, state?.timeline?.day, g.__DAY, g.day];
+  for (const v of cands) { const n = Number(v); if (Number.isFinite(n) && n > 0) return n; }
+  return 1;
 }


### PR DESCRIPTION
## Summary
- expose getCurrentDay utility with fallbacks to global state
- sync React day state to global `__DAY` to avoid undefined errors

## Testing
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68b9e8db9f5c8325bd6e87aef114fe24