### PR TITLE
fix: sync and use current day globally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,8 @@ import { pickRandomContainer, openContainer } from "./systems/containers";
 import { getCurrentDay } from "./utils/day";
 import type { GameState as GameWorldState, ContainersState } from "./types/game";
 
+const currentDay = getCurrentDay((globalThis as any).__GAME_STATE__ ?? (globalThis as any));
+
 
 // === Botiquín helpers ===
 type MedkitItem = { name: string; medicines: number; kind?: string };
@@ -1577,7 +1579,6 @@ function advanceTurn() {
     if(!containersState.lastOpenedWasContainer){
       const rollC = Math.random();
       if(rollC < 0.40){
-        const currentDay = getCurrentDay({ day });
         const c = pickRandomContainer(currentDay, { resources, containersState });
         if(c){
           gameLog(`🧭 Encontraste un contenedor: ${c.name} (${c.place})`);

--- a/src/GameRoot.tsx
+++ b/src/GameRoot.tsx
@@ -230,6 +230,7 @@ export default function GameRoot(){
   // Estado base
   const [state, setState] = useState<GameState>("playing");
   const [day, setDay] = useState(1);
+  React.useEffect(() => { (globalThis as any).__DAY = day; }, [day]);
   const [phase, setPhase] = useState<Phase>("dawn");
   const [clockMs, setClockMs] = useState<number>(DAY_LENGTH_MS);
   const [timeRunning, setTimeRunning] = useState(false);


### PR DESCRIPTION
## Summary
- define global currentDay helper and use it when exploring containers
- sync `__DAY` global from game root state

## Testing
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68ba17ebaa1883258df871e81c064f1f