### PR TITLE
feat: add ammo reload system from ammo boxes

### DIFF
--- a/src/components/overlays/AmmoReloadModal.tsx
+++ b/src/components/overlays/AmmoReloadModal.tsx
@@ -1,0 +1,84 @@
+import React, { useMemo, useState } from "react";
+import { findAmmoBoxInBackpack, getReloadableWeapons } from "../../helpers";
+
+type Weapon = { id:string; name:string };
+type Props = {
+  isOpen: boolean;
+  player: any|null;
+  onClose: () => void;
+  onConfirm: (weaponId:string, bullets:number) => void;
+};
+
+export default function AmmoReloadModal({ isOpen, player, onClose, onConfirm }: Props){
+  if(!isOpen || !player) return null;
+
+  const boxInfo = useMemo(()=>findAmmoBoxInBackpack(player), [player]);
+  const weapons = useMemo(()=>getReloadableWeapons(player), [player]);
+  const [wid, setWid] = useState<string>(weapons[0]?.id ?? "");
+  const maxBullets = Math.max(0, boxInfo?.box?.bullets ?? 0);
+  const [count, setCount] = useState<number>(Math.min(5, maxBullets)); // default 5 para UX
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="w-full max-w-lg rounded-2xl bg-neutral-900 text-neutral-100 shadow-2xl border border-neutral-800">
+        <div className="p-5 border-b border-neutral-800">
+          <h3 className="text-xl font-bold">Recarga tu arma</h3>
+          <p className="text-xs text-neutral-400 mt-1">Disponible en la caja: <b>{maxBullets}</b> municiones</p>
+        </div>
+
+        <div className="p-5 space-y-5">
+          {weapons.length > 1 ? (
+            <div>
+              <div className="text-sm mb-2">Elige arma a recargar</div>
+              <div className="flex flex-wrap gap-2">
+                {weapons.map(w=>(
+                  <button key={w.id}
+                    className={`px-3 py-1 rounded-lg border ${wid===w.id ? 'border-emerald-500 bg-emerald-600/20' : 'border-neutral-700 bg-neutral-800'}`}
+                    onClick={()=>setWid(w.id)}
+                  >
+                    {w.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div>
+              <div className="text-sm mb-1">Arma</div>
+              <div className="px-3 py-2 rounded-lg bg-neutral-800 border border-neutral-700 inline-block">{weapons[0]?.name ?? '—'}</div>
+            </div>
+          )}
+
+          <div className="rounded-xl border border-neutral-800 p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="font-semibold">Municiones a cargar</div>
+                <div className="text-xs text-neutral-400">Selecciona cuántas transferir desde la caja</div>
+              </div>
+              <div className="flex items-center gap-2">
+                <button className="px-3 py-1 rounded-lg bg-neutral-800 border border-neutral-700"
+                        onClick={()=>setCount(c=>Math.max(0, c-1))}>-</button>
+                <span className="w-12 text-center font-bold">{count}</span>
+                <button className="px-3 py-1 rounded-lg bg-neutral-800 border border-neutral-700"
+                        onClick={()=>setCount(c=>Math.min(maxBullets, c+1))}>+</button>
+              </div>
+            </div>
+          </div>
+
+          <p className="text-xs text-neutral-400">recuerda utilizar tu munición de forma inteligente</p>
+        </div>
+
+        <div className="p-5 border-t border-neutral-800 flex justify-end gap-2">
+          <button className="rounded-lg px-4 py-2 bg-neutral-800 hover:bg-neutral-700" onClick={onClose}>Cancelar</button>
+          <button
+            className={`rounded-lg px-4 py-2 ${count>0 && wid ? 'bg-emerald-600 hover:bg-emerald-500 text-white' : 'bg-neutral-700 text-neutral-400 cursor-not-allowed'}`}
+            disabled={!wid || count<=0}
+            onClick={()=>onConfirm(wid, count)}
+          >
+            Continuar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,70 @@
+/** normaliza un item potencialmente string a caja con bullets */
+export function normalizeAmmoBox(it:any): { name:"Caja de munición"; bullets:number } | null {
+  if(!it) return null;
+  if(typeof it === "string") {
+    const s = it.trim().toLowerCase();
+    if(s === "caja de munición" || s === "caja de municion") return { name:"Caja de munición", bullets:15 };
+    return null;
+  }
+  if(it && typeof it === "object" && (it.name?.toLowerCase?.() === "caja de munición" || it.name?.toLowerCase?.() === "caja de municion")) {
+    const n = Number(it.bullets);
+    return { name:"Caja de munición", bullets: Number.isFinite(n) && n>0 ? n : 15 };
+  }
+  return null;
+}
+
+/** devuelve índice y caja normalizada de la PRIMERA caja en backpack; si existe, también la versión normalizada para actualizar */
+export function findAmmoBoxInBackpack(p:any): { index:number; box:{name:"Caja de munición"; bullets:number} } | null {
+  const bp = Array.isArray(p?.backpack) ? p.backpack : [];
+  for(let i=0;i<bp.length;i++){
+    const norm = normalizeAmmoBox(bp[i]);
+    if(norm) return { index:i, box:norm };
+  }
+  return null;
+}
+
+/** sustituye en mochila el item en idx por objeto con bullets actualizados, o lo elimina si bullets<=0 */
+export function applyAmmoBoxDeltaToBackpack(p:any, idx:number, remaining:number){
+  const bp = Array.isArray(p?.backpack) ? [...p.backpack] : [];
+  if(remaining <= 0){
+    bp.splice(idx,1);
+  } else {
+    bp[idx] = { name:"Caja de munición", bullets: remaining };
+  }
+  return bp;
+}
+
+/** lista de armas elegibles del jugador (seguro y minimalista) */
+export function getReloadableWeapons(p:any): { id:string; name:string }[] {
+  const list: {id:string; name:string}[] = [];
+  // 1) arma seleccionada si existe
+  if (p?.selectedWeaponId) list.push({ id: p.selectedWeaponId, name: String(p.selectedWeaponId) });
+  // 2) armas que ya tengan munición registrada
+  if (p?.ammoByWeapon && typeof p.ammoByWeapon === "object") {
+    Object.keys(p.ammoByWeapon).forEach(id=>{
+      if(!list.find(w=>w.id===id)) list.push({ id, name: id });
+    });
+  }
+  // 3) strings de la mochila que parezcan armas (evitar fists)
+  const bp = Array.isArray(p?.backpack) ? p.backpack : [];
+  bp.forEach((it:any)=>{
+    if (typeof it === "string") {
+      const s = it.toLowerCase();
+      if (!/fists|puños|manos/.test(s) && /pistola|rifle|subfusil|escopeta|smg|ar|revolver|arma/.test(s)) {
+        if(!list.find(w=>w.id===it)) list.push({ id: it, name: it });
+      }
+    }
+  });
+  // fallback: si quedó vacío, usa “fists” o el selected como único
+  if(list.length===0 && p?.selectedWeaponId) list.push({ id:p.selectedWeaponId, name: p.selectedWeaponId });
+  return list;
+}
+
+/** suma balas a arma del jugador (exactamente amount) */
+export function addAmmoToWeapon(p:any, weaponId:string, amount:number){
+  const map = { ...(p?.ammoByWeapon ?? {}) };
+  const prev = Number(map[weaponId] ?? 0);
+  map[weaponId] = prev + Math.max(0, Math.floor(amount));
+  return map;
+}
+


### PR DESCRIPTION
## Summary
- add helpers for handling ammo boxes and weapons
- create AmmoReloadModal component to transfer bullets from backpack to weapon
- wire modal into App with grey pulse button and turn consumption

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba3ccc47b48325b809b2ecc93b6580