### PR TITLE
Permitir selección y aviso de arma sin munición

### DIFF
--- a/src/components/WeaponPicker.tsx
+++ b/src/components/WeaponPicker.tsx
@@ -37,18 +37,21 @@ export default function WeaponPicker({ player, backpack, onSelect }: WeaponPicke
           const selected = sel === w.id;
           const ranged = isRangedWeapon(w);
           const ammo = ranged ? getAmmoFor(player, w.id) : null;
-          const disabled = ranged && (ammo ?? 0) <= 0;
+          const noAmmo = ranged && (ammo ?? 0) <= 0;
           return (
             <button
               key={w.id}
-              onClick={() => !disabled && onSelect(w.id)}
+              onClick={() => onSelect(w.id)}
               className={[
-                "text-left p-2 rounded-xl border transition",
+                "relative text-left p-2 rounded-xl border transition",
                 selected ? "border-indigo-400 bg-indigo-500/10" : "border-white/10 hover:border-white/20",
-                disabled ? "opacity-60 cursor-not-allowed" : "cursor-pointer"
+                noAmmo ? "opacity-60" : ""
               ].join(" ")}
             >
-              <div className="font-medium">{w.name}</div>
+              <div className="font-medium">
+                {w.name}
+                {noAmmo && <span className="ml-2 text-[10px] text-red-400">Sin munición</span>}
+              </div>
               <div className="text-xs opacity-80">
                 Daño: {w?.damage ? `${w.damage.min ?? "?"}–${w.damage.max ?? "?"}` : "?"}
               </div>

--- a/src/components/overlays/NoAmmoModal.tsx
+++ b/src/components/overlays/NoAmmoModal.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+type Props = {
+  open: boolean;
+  enemyName?: string;
+  onClose: () => void;
+};
+
+export default function NoAmmoModal({ open, enemyName, onClose }: Props){
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+      <div className="relative z-10 max-w-md mx-auto my-12 p-6 rounded-2xl bg-neutral-900 border border-neutral-800 shadow-2xl">
+        <h3 className="text-xl font-bold">El arma no tiene munición</h3>
+        <p className="text-sm text-neutral-300 mt-2">
+          Recarga tu arma para disparar a <b>{enemyName ?? "el enemigo"}</b>.
+        </p>
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg bg-neutral-800 hover:bg-neutral-700">
+            Aceptar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Permite elegir armas sin munición mostrando la insignia "Sin munición"
- Jugadores inician con 3 balas en la pistola
- Modal de advertencia cuando se intenta disparar sin munición

## Testing
- `npm test` *(missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba904ca7988325b76fc80ba5eda187