### PR TITLE
Scope tap-to-enter to summary modals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import { day2ExplorationCards } from "./data/days/day2/explorationCards.day2";
 import { day3ExplorationCards } from "./data/days/day3/explorationCards.day3";
 import type { ExplorationCard } from "./data/explorationCards";
 import type { DecisionCard } from "./data/decisionCards";
+import { useEnterOnTap } from "./hooks/useEnterOnTap";
 import {
   Conditions,
   hasCondition,
@@ -341,6 +342,32 @@ export default function App(){
   const [showReloadModal, setShowReloadModal] = useState(false);
   const [dayEndLines, setDayEndLines] = useState<string[]>([]);
   const [noAmmo, setNoAmmo] = useState<{open:boolean; enemyName?:string}>({ open:false });
+
+  const isSummaryOpen = showDayEnd || showCombatEnd;
+
+  useEnterOnTap({
+    enabled: true,
+    getIsSummaryOpen: () => isSummaryOpen,
+    summarySelector: '[data-enter-scope="summary"]'
+  });
+
+  useEffect(() => {
+    const onKeyDownCapture = (e: KeyboardEvent) => {
+      if (e.key !== "Enter") return;
+      if (!isSummaryOpen) return;
+
+      const scopeEl = document.querySelector('[data-enter-scope="summary"]');
+      if (!scopeEl) return;
+
+      const target = e.target as Node | null;
+      if (target && !scopeEl.contains(target)) {
+        e.stopPropagation();
+        e.preventDefault();
+      }
+    };
+    document.addEventListener("keydown", onKeyDownCapture, true);
+    return () => document.removeEventListener("keydown", onKeyDownCapture, true);
+  }, [isSummaryOpen]);
 
   // Turnos
   const [isEnemyPhase, setIsEnemyPhase] = useState<boolean>(false);

--- a/src/components/overlays/CombatEndSummary.tsx
+++ b/src/components/overlays/CombatEndSummary.tsx
@@ -48,7 +48,7 @@ export default function CombatEndSummary({ open, lines, onFinish }: Props) {
   const finished = !typing && idx >= lines.length - 1;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center" data-enter-scope="summary" data-no-enter-tap="true">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
       <div className="relative z-10 w-full max-w-xl mx-4 rounded-2xl p-6 bg-zinc-900/95 border border-white/10 shadow-xl">
         <h2 className="text-lg font-bold text-emerald-400 mb-3">Fin del enfrentamiento</h2>

--- a/src/components/overlays/DayEndModal.tsx
+++ b/src/components/overlays/DayEndModal.tsx
@@ -45,7 +45,7 @@ export default function DayEndModal({
   const finished = !typing && idx>=lines.length-1;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center" data-enter-scope="summary" data-no-enter-tap="true">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm"/>
       <div className="relative z-10 w-full max-w-xl mx-4 rounded-2xl p-6 bg-zinc-900/95 border border-white/10 shadow-xl">
         <h2 className="text-lg font-bold text-amber-300 mb-2">Día concluido</h2>

--- a/src/hooks/useEnterOnTap.ts
+++ b/src/hooks/useEnterOnTap.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from "react";
+
+type Options = {
+  enabled?: boolean;
+  /** Retorna true si un modal de resumen está abierto */
+  getIsSummaryOpen?: () => boolean;
+  /** Selector del contenedor del resumen */
+  summarySelector?: string; // default: '[data-enter-scope="summary"]'
+};
+
+function isInteractive(el: Element | null): boolean {
+  if (!el) return false;
+  // Permite desactivar por zona con data-no-enter-tap
+  if ((el as HTMLElement).closest?.('[data-no-enter-tap="true"]')) return true;
+
+  const node = el as HTMLElement;
+  const tag  = (node.tagName || "").toLowerCase();
+  const role = node.getAttribute?.("role") || "";
+  const editable = node.isContentEditable;
+  const cls = String((node as any).className || "");
+
+  if (editable) return true;
+  if (["button","input","textarea","select","a","label","summary","details"].includes(tag)) return true;
+  if (["button","switch","tab","menuitem"].includes(role)) return true;
+  if (/\b(btn|button|toggle|dropdown|select|input)\b/i.test(cls)) return true;
+
+  return false;
+}
+
+export function useEnterOnTap(opts: Options = {}) {
+  const { enabled = true, getIsSummaryOpen, summarySelector = '[data-enter-scope="summary"]' } = opts;
+  const lastRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const shouldSkip = (ev: PointerEvent): boolean => {
+      // primario solamente
+      if (ev.pointerType === "mouse" && ev.button !== 0) return true;
+      // evitar taps sobre UI interactiva
+      if (isInteractive(ev.target as Element)) return true;
+      // evitar si hay selección de texto
+      const sel = window.getSelection?.();
+      if (sel && !sel.isCollapsed) return true;
+      // throttling simple
+      const now = Date.now();
+      if (now - lastRef.current < 200) return true;
+      lastRef.current = now;
+      return false;
+    };
+
+    const onPointerDown = (ev: PointerEvent) => {
+      if (shouldSkip(ev)) return;
+
+      const summaryOpen = getIsSummaryOpen?.() ?? false;
+      const scopeEl = document.querySelector(summarySelector);
+
+      // Si el resumen está abierto, solo permitimos Enter si el tap ocurrió DENTRO del modal de resumen
+      if (summaryOpen && scopeEl) {
+        if (!scopeEl.contains(ev.target as Node)) return;
+      }
+
+      // Despachar el mismo keydown Enter que maneja la app
+      const e = new KeyboardEvent("keydown", {
+        key: "Enter",
+        code: "Enter",
+        keyCode: 13,
+        which: 13,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      // Si existe scope (resumen abierto), despachar sobre ese contenedor; sino, sobre document
+      if (summaryOpen && scopeEl) {
+        scopeEl.dispatchEvent(e);
+      } else {
+        document.dispatchEvent(e);
+      }
+    };
+
+    document.addEventListener("pointerdown", onPointerDown, { passive: true });
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown as any);
+    };
+  }, [enabled, getIsSummaryOpen, summarySelector]);
+}


### PR DESCRIPTION
## Summary
- Map pointer taps to Enter with new `useEnterOnTap` hook
- Restrict global Enter when summary modals are open
- Mark DayEnd and Combat summary modals with summary scope attributes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba96b5fc2c832584a1cf783f253864