### PR TITLE
Add combat action feedback and medical kit modal

### DIFF
--- a/src/components/Combat/ActionBar.tsx
+++ b/src/components/Combat/ActionBar.tsx
@@ -1,0 +1,36 @@
+import React, { useMemo } from "react";
+
+type Enemy = { id: string; trait?: string };
+
+interface Props {
+  player: { isGrappled?: boolean };
+  enemies: Enemy[];
+  flee: () => void;
+}
+
+export default function ActionBar({ player, enemies, flee }: Props) {
+  const canFlee = useMemo(() => {
+    if (player.isGrappled) return { ok: false, reason: "Estás atrapado" };
+    if (enemies.some(e => e.trait === "BloqueaHuida")) {
+      return { ok: false, reason: "El enemigo te bloquea" };
+    }
+    return { ok: true, reason: "" };
+  }, [player, enemies]);
+
+  return (
+    <div>
+      <button
+        className="px-3 py-1 rounded bg-slate-700 text-white disabled:opacity-50"
+        disabled={!canFlee.ok}
+        onClick={() => (canFlee.ok ? flee() : null)}
+        title={!canFlee.ok ? canFlee.reason : undefined}
+      >
+        Huir
+      </button>
+      {!canFlee.ok && (
+        <div className="text-xs text-red-300 mt-1">{canFlee.reason}</div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/Combat/EnemiesList.tsx
+++ b/src/components/Combat/EnemiesList.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from "react";
+
+type Enemy = {
+  id: string;
+  name: string;
+  hp: number;
+  maxHp: number;
+};
+
+interface Props {
+  enemies: Enemy[];
+  attack: (enemyId: string) => void;
+}
+
+export default function EnemiesList({ enemies, attack }: Props) {
+  const [selectedEnemyId, setSelectedEnemyId] = useState<string | null>(null);
+
+  return (
+    <div>
+      <ul className="space-y-2">
+        {enemies.map(e => (
+          <li
+            key={e.id}
+            onClick={() => setSelectedEnemyId(e.id)}
+            className={`p-2 rounded border cursor-pointer ${
+              selectedEnemyId === e.id
+                ? "border-amber-400 bg-amber-900/20"
+                : "border-slate-600"
+            }`}
+          >
+            <div className="flex justify-between">
+              <span>{e.name}</span>
+              <span>
+                HP {e.hp}/{e.maxHp}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <button
+        onClick={() => selectedEnemyId && attack(selectedEnemyId)}
+        disabled={!selectedEnemyId}
+        className="mt-2 px-3 py-1 rounded bg-amber-600 text-white disabled:opacity-50"
+      >
+        Atacar
+      </button>
+    </div>
+  );
+}
+

--- a/src/components/Combat/Header.tsx
+++ b/src/components/Combat/Header.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+type Actor = { name: string };
+
+interface Props {
+  turnOrder: Actor[];
+  currentIndex: number;
+}
+
+export default function Header({ turnOrder, currentIndex }: Props) {
+  const current = turnOrder[currentIndex];
+  const next = turnOrder[(currentIndex + 1) % turnOrder.length];
+
+  return (
+    <div className="flex items-baseline gap-2">
+      <h3 className="text-lg font-bold">Turno de {current.name}</h3>
+      <span className="text-xs opacity-70">Siguiente: {next.name}</span>
+    </div>
+  );
+}
+

--- a/src/components/overlays/MedicalKitModal.tsx
+++ b/src/components/overlays/MedicalKitModal.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+
+type MedicalKit = { id: string; medCount: number };
+
+interface Props {
+  open: boolean;
+  kit: MedicalKit | null;
+  setGameState: React.Dispatch<React.SetStateAction<any>>;
+  onClose: () => void;
+}
+
+export default function MedicalKitModal({ open, kit, setGameState, onClose }: Props) {
+  const [isBusy, setIsBusy] = useState(false);
+  const canExtract = !!kit && kit.medCount > 0 && !isBusy;
+
+  if (!open) return null;
+
+  const handleExtract = async () => {
+    if (!kit || kit.medCount <= 0) return;
+    setIsBusy(true);
+    try {
+      setGameState(prev => {
+        const next = structuredClone(prev);
+        const k: MedicalKit | undefined = next.items.find((i: any) => i.id === kit.id);
+        if (!k || k.medCount <= 0) return prev;
+        k.medCount -= 1;
+        next.resources.medicine = (next.resources.medicine ?? 0) + 1;
+        return next;
+      });
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+      <div className="relative z-10 max-w-md w-full mx-4 rounded-2xl p-6 bg-zinc-900/95 border border-white/10 text-white">
+        <h3 className="text-lg font-bold mb-3">Botiquín</h3>
+        <button
+          onClick={handleExtract}
+          disabled={!canExtract}
+          className="px-3 py-1 rounded bg-emerald-600 text-white disabled:opacity-50"
+        >
+          Sacar medicina
+        </button>
+        <div className="text-xs opacity-70 mt-1">En botiquín: {kit?.medCount ?? 0}</div>
+        <div className="flex justify-end mt-4">
+          <button
+            className="px-3 py-1 rounded border border-white/15 hover:bg-white/5"
+            onClick={onClose}
+          >
+            Cerrar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ActionBar with flee validation and feedback
- show current and next actors in combat header
- enable enemy selection highlighting with attack button
- implement medical kit modal with safe medicine extraction

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0bee93c548325bfc2b6cecd60837c