### PR TITLE
feat: add weapon selection and ammo handling

### DIFF
--- a/src/components/Combat/ActionBar.tsx
+++ b/src/components/Combat/ActionBar.tsx
@@ -1,27 +1,71 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
+import useAttackFlow from "../combat/AttackFlow";
+import ChooseWeaponModal from "../combat/ChooseWeaponModal";
+import { getAvailableWeapons, WeaponOpt } from "../../systems/combat/getAvailableWeapons";
 
 type Enemy = { id: string; trait?: string };
 
 interface Props {
   player: { isGrappled?: boolean; status?: { infected?: boolean; bleeding?: boolean } };
+  resources: { ammo?: number };
   enemies: Enemy[];
   flee: () => void;
   selfHeal: () => void;
+  doAttack: (weaponId: string) => void;
 }
 
-export default function ActionBar({ player, enemies, flee, selfHeal }: Props) {
+export default function ActionBar({
+  player,
+  resources,
+  enemies,
+  flee,
+  selfHeal,
+  doAttack,
+}: Props) {
   const canFlee = useMemo(() => {
     if (player.isGrappled) return { ok: false, reason: "Estás atrapado" };
-    if (enemies.some(e => e.trait === "BloqueaHuida")) {
+    if (enemies.some((e) => e.trait === "BloqueaHuida")) {
       return { ok: false, reason: "El enemigo te bloquea" };
     }
     return { ok: true, reason: "" };
   }, [player, enemies]);
 
+  const [weaponChoices, setWeaponChoices] = useState<WeaponOpt[] | null>(null);
+  const { startAttack } = useAttackFlow(player, resources, doAttack);
+
+  const availableWeapons = useMemo(
+    () => getAvailableWeapons(player, resources),
+    [player, resources]
+  );
+  const canAttack = availableWeapons.some((w) => w.usable);
+
+  const handleAttack = () => {
+    const res = startAttack();
+    if (!res.needChooser && res.chosen) {
+      doAttack(res.chosen);
+    } else if (res.needChooser) {
+      setWeaponChoices(res.weapons);
+    }
+  };
+
   const hasAilment = !!(player.status?.infected || player.status?.bleeding);
 
   return (
     <div className="flex gap-4">
+      <div>
+        <button
+          className="px-3 py-1 rounded bg-amber-700 text-white disabled:opacity-50"
+          disabled={!canAttack || weaponChoices !== null}
+          onClick={() => (canAttack ? handleAttack() : null)}
+          title={!canAttack ? "No tienes armas utilizables" : undefined}
+        >
+          Atacar
+        </button>
+        {!canAttack && (
+          <div className="text-xs text-amber-300 mt-1">No tienes armas utilizables</div>
+        )}
+      </div>
+
       <div>
         <button
           className="px-3 py-1 rounded bg-slate-700 text-white disabled:opacity-50"
@@ -39,7 +83,7 @@ export default function ActionBar({ player, enemies, flee, selfHeal }: Props) {
       <div>
         <button
           disabled={!hasAilment}
-          title={!hasAilment ? 'No tienes afecciones que curar' : undefined}
+          title={!hasAilment ? "No tienes afecciones que curar" : undefined}
           onClick={() => hasAilment && selfHeal()}
           className="px-3 py-1 rounded bg-sky-700 text-white disabled:opacity-50"
         >
@@ -49,7 +93,17 @@ export default function ActionBar({ player, enemies, flee, selfHeal }: Props) {
           <div className="text-xs text-sky-300 mt-1">Nada que curar</div>
         )}
       </div>
+
+      {weaponChoices && (
+        <ChooseWeaponModal
+          weapons={weaponChoices}
+          onClose={() => setWeaponChoices(null)}
+          doAttack={(id) => {
+            doAttack(id);
+            setWeaponChoices(null);
+          }}
+        />
+      )}
     </div>
   );
 }
-

--- a/src/components/combat/AttackFlow.tsx
+++ b/src/components/combat/AttackFlow.tsx
@@ -1,0 +1,52 @@
+import { useCallback } from "react";
+import { getAvailableWeapons, WeaponOpt } from "../../systems/combat/getAvailableWeapons";
+
+export interface AttackFlowResultChoose {
+  needChooser: true;
+  weapons: WeaponOpt[];
+}
+
+export interface AttackFlowResultDirect {
+  needChooser: false;
+  chosen: string | null;
+  weapons: WeaponOpt[];
+}
+
+export type AttackFlowResult = AttackFlowResultChoose | AttackFlowResultDirect;
+
+/**
+ * Hook que gestiona la lógica de selección de arma antes de atacar.
+ *
+ * No ejecuta el ataque directamente. En su lugar, devuelve información
+ * para que el componente decida si mostrar un selector o atacar de inmediato.
+ */
+export function useAttackFlow(
+  player: any,
+  resources: { ammo?: number },
+  _doAttack: (weaponId: string) => void
+) {
+  // _doAttack no se usa aquí directamente pero se admite por diseño
+  void _doAttack;
+
+  const startAttack = useCallback((): AttackFlowResult => {
+    const weapons = getAvailableWeapons(player, resources);
+    const usable = weapons.filter((w) => w.usable);
+
+    if (usable.length === 0) {
+      if (typeof window !== "undefined") {
+        window.alert("No tienes armas utilizables");
+      }
+      return { needChooser: false, chosen: null, weapons };
+    }
+
+    if (usable.length === 1) {
+      return { needChooser: false, chosen: usable[0].id, weapons };
+    }
+
+    return { needChooser: true, weapons };
+  }, [player, resources]);
+
+  return { startAttack };
+}
+
+export default useAttackFlow;

--- a/src/components/combat/ChooseWeaponModal.tsx
+++ b/src/components/combat/ChooseWeaponModal.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef } from "react";
+import { WeaponOpt } from "../../systems/combat/getAvailableWeapons";
+
+interface Props {
+  weapons: WeaponOpt[];
+  onClose: () => void;
+  doAttack: (weaponId: string) => void;
+}
+
+export default function ChooseWeaponModal({ weapons, onClose, doAttack }: Props) {
+  const firstBtnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    firstBtnRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handler = (ev: KeyboardEvent) => {
+      if (ev.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  const choose = (id: string, usable: boolean) => {
+    if (!usable) return;
+    doAttack(id);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50" role="dialog" aria-modal="true">
+      <div className="bg-neutral-900 border border-neutral-700 rounded p-4 w-80 max-w-full">
+        <h2 className="text-lg mb-3">Elige arma</h2>
+        <div className="space-y-2">
+          {weapons.map((w, idx) => (
+            <button
+              key={w.id}
+              ref={idx === 0 ? firstBtnRef : undefined}
+              disabled={!w.usable}
+              title={!w.usable && w.reason ? w.reason : undefined}
+              onClick={() => choose(w.id, w.usable)}
+              className={`block w-full text-left px-3 py-1 rounded border ${
+                w.usable ? "border-slate-500" : "border-slate-700 opacity-50"
+              }`}
+            >
+              {w.label}
+              {!w.usable && w.reason && (
+                <span className="ml-2 text-xs text-red-400">{w.reason}</span>
+              )}
+            </button>
+          ))}
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-3 py-1 rounded bg-slate-700 text-white"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/systems/combat/getAvailableWeapons.ts
+++ b/src/systems/combat/getAvailableWeapons.ts
@@ -6,9 +6,10 @@ export type WeaponOpt = { id: string; label: string; usable: boolean; reason?: s
 type Player = { inventory?: any[] };
 type Resources = { ammo?: number };
 
+/** Comprueba si el jugador porta un item de cierto tipo */
 function hasItem(p: Player, type: string): boolean {
   return Array.isArray(p.inventory) && p.inventory.some((i: any) => {
-    if (typeof i === 'string') return i === type;
+    if (typeof i === "string") return i === type;
     return i?.type === type || i?.id === type || i?.name === type;
   });
 }

--- a/src/systems/combat/resolveAttack.ts
+++ b/src/systems/combat/resolveAttack.ts
@@ -1,0 +1,21 @@
+/**
+ * Resuelve un ataque del jugador consumiendo munición si corresponde
+ * y registrando el evento en el log.
+ */
+export function resolveAttack(state: any, weaponId: string, atk: { name: string }) {
+  const next = structuredClone(state);
+  if (weaponId === "pistol") {
+    const ammo = Math.max(0, (next.resources?.ammo ?? 0) - 1);
+    next.resources = { ...(next.resources || {}), ammo };
+    const logEntry = {
+      ts: Date.now(),
+      text: `${atk.name} dispara Pistola (munición restante: ${ammo})`,
+    };
+    const logs = Array.isArray(next.ui?.logs) ? [...next.ui.logs] : [];
+    logs.push(logEntry);
+    next.ui = { ...(next.ui || {}), logs };
+  }
+  return next;
+}
+
+export default resolveAttack;


### PR DESCRIPTION
## Summary
- add helper to list available weapons including ammo-based pistol usability
- allow starting attacks with automatic weapon choice or modal when multiple options
- track ammo spending and log pistol shots

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0d73996ec832580ede8c3df5fe068