### PR TITLE
Use player ammo for weapon selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2172,7 +2172,6 @@ function advanceTurn() {
         {activePlayer && (
           <WeaponPicker
             player={activePlayer}
-            resources={resources}
             onSelect={(wid) => setPlayerSelectedWeapon(activePlayer.id, wid)}
           />
         )}

--- a/src/components/Combat/ActionBar.tsx
+++ b/src/components/Combat/ActionBar.tsx
@@ -7,7 +7,6 @@ type Enemy = { id: string; trait?: string };
 
 interface Props {
   player: { isGrappled?: boolean; status?: { infected?: boolean; bleeding?: boolean } };
-  resources: { ammo?: number };
   enemies: Enemy[];
   flee: () => void;
   selfHeal: () => void;
@@ -16,7 +15,6 @@ interface Props {
 
 export default function ActionBar({
   player,
-  resources,
   enemies,
   flee,
   selfHeal,
@@ -31,12 +29,9 @@ export default function ActionBar({
   }, [player, enemies]);
 
   const [weaponChoices, setWeaponChoices] = useState<WeaponOpt[] | null>(null);
-  const { startAttack } = useAttackFlow(player, resources, doAttack);
+  const { startAttack } = useAttackFlow(player, doAttack);
 
-  const availableWeapons = useMemo(
-    () => getAvailableWeapons(player, resources),
-    [player, resources]
-  );
+  const availableWeapons = useMemo(() => getAvailableWeapons(player), [player]);
   const canAttack = availableWeapons.some((w) => w.usable);
 
   const handleAttack = () => {

--- a/src/components/WeaponPicker.tsx
+++ b/src/components/WeaponPicker.tsx
@@ -3,15 +3,11 @@ import { getAvailableWeapons, WeaponOpt } from "../systems/combat/getAvailableWe
 
 type WeaponPickerProps = {
   player: any;
-  resources: { ammo?: number };
   onSelect: (weaponId: string) => void;
 };
 
-export default function WeaponPicker({ player, resources, onSelect }: WeaponPickerProps) {
-  const weapons = useMemo<WeaponOpt[]>(
-    () => getAvailableWeapons(player, resources),
-    [player, resources]
-  );
+export default function WeaponPicker({ player, onSelect }: WeaponPickerProps) {
+  const weapons = useMemo<WeaponOpt[]>(() => getAvailableWeapons(player), [player]);
 
   return (
     <div className="mt-3">

--- a/src/components/combat/AttackFlow.tsx
+++ b/src/components/combat/AttackFlow.tsx
@@ -22,14 +22,13 @@ export type AttackFlowResult = AttackFlowResultChoose | AttackFlowResultDirect;
  */
 export function useAttackFlow(
   player: any,
-  resources: { ammo?: number },
   _doAttack: (weaponId: string) => void
 ) {
   // _doAttack no se usa aquí directamente pero se admite por diseño
   void _doAttack;
 
   const startAttack = useCallback((): AttackFlowResult => {
-    const weapons = getAvailableWeapons(player, resources);
+    const weapons = getAvailableWeapons(player);
     const usable = weapons.filter((w) => w.usable);
 
     if (usable.length === 0) {
@@ -44,7 +43,7 @@ export function useAttackFlow(
     }
 
     return { needChooser: true, weapons };
-  }, [player, resources]);
+  }, [player]);
 
   return { startAttack };
 }

--- a/src/systems/combat/getAvailableWeapons.ts
+++ b/src/systems/combat/getAvailableWeapons.ts
@@ -3,8 +3,7 @@
 
 export type WeaponOpt = { id: string; label: string; usable: boolean; reason?: string };
 
-type Player = { inventory?: any[] };
-type Resources = { ammo?: number };
+type Player = { inventory?: any[]; ammo?: number };
 
 /** Comprueba si el jugador porta un item de cierto tipo */
 function hasItem(p: Player, type: string): boolean {
@@ -14,7 +13,7 @@ function hasItem(p: Player, type: string): boolean {
   });
 }
 
-export function getAvailableWeapons(player: Player, resources: Resources): WeaponOpt[] {
+export function getAvailableWeapons(player: Player): WeaponOpt[] {
   const list: WeaponOpt[] = [
     { id: 'fists', label: 'Puños (1–2)', usable: true },
   ];
@@ -23,12 +22,21 @@ export function getAvailableWeapons(player: Player, resources: Resources): Weapo
     list.push({ id: 'knife', label: 'Navaja (1–6)', usable: true });
   }
 
-  const hasPistol = hasItem(player, 'pistol');
-  if (hasPistol) {
-    const ammo = resources.ammo ?? 0;
+  const ammo = player.ammo ?? 0;
+
+  if (hasItem(player, 'pistol')) {
     list.push({
       id: 'pistol',
       label: `Pistola (2–8) — Munición: ${ammo}`,
+      usable: ammo > 0,
+      reason: ammo > 0 ? undefined : 'Sin munición',
+    });
+  }
+
+  if (hasItem(player, 'rifle')) {
+    list.push({
+      id: 'rifle',
+      label: `Rifle (4–12) — Munición: ${ammo}`,
       usable: ammo > 0,
       reason: ammo > 0 ? undefined : 'Sin munición',
     });


### PR DESCRIPTION
## Summary
- Show pistol and rifle based on `player.inventory` using shared `player.ammo`
- Remove `resources.ammo` dependence from weapon picker and attack flow
- Adjust action bar and hook to reflect new weapon availability logic

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0eff9f9148325892f4c3a537e5ff2