### PR TITLE
Enable tap-to-enter in combat end summary overlay

### DIFF
--- a/src/components/overlays/CombatEndSummary.tsx
+++ b/src/components/overlays/CombatEndSummary.tsx
@@ -88,7 +88,7 @@ export default function CombatEndSummary({ open, lines, onFinish, autoCloseMs = 
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center" data-enter-scope="summary">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
       <div className="relative z-10 w-full max-w-xl mx-4 rounded-2xl p-6 bg-zinc-900/95 border border-white/10 shadow-xl">
         <h2 className="text-lg font-bold text-emerald-400 mb-3">Fin del enfrentamiento</h2>


### PR DESCRIPTION
## Summary
- mark CombatEndSummary overlay with the summary scope so tap gestures dispatch Enter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f46740b88325b91666c98597e129