### PR TITLE
Add debug combat summary overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -380,6 +380,18 @@ export default function App(){
   // Cuando una acción del jugador requiere terminar con Enter, guardamos el "qué hacer después"
   const postActionContinueRef = useRef<null | (() => void)>(null);
 
+  // DEBUG: abrir resumen con líneas fake
+  useEffect(() => {
+    setCombatEndLines([
+      "— RESUMEN DEL ENFRENTAMIENTO —",
+      "Golpes directos: 2",
+      "Golpes fallidos: 1",
+      "Botín: —",
+    ]);
+    setShowCombatEnd(true);
+    setControlsLocked(true);
+  }, []);
+
   function touchPlayerStats(playerId: string) {
     setBattleStats(prev => {
       const bp = prev.byPlayer[playerId] ?? { meleeHits:0, meleeMisses:0, rangedHits:0, rangedMisses:0, heals:0, points:0 };

--- a/src/components/overlays/CombatEndSummary.tsx
+++ b/src/components/overlays/CombatEndSummary.tsx
@@ -99,6 +99,12 @@ export default function CombatEndSummary({ open, lines, onFinish, autoCloseMs = 
 
         <div className="mt-2 text-xs opacity-70">Presiona Enter para continuar</div>
 
+        {!finished && (
+          <div className="mt-3 text-xs text-center opacity-80">
+            Toca aquí para continuar
+          </div>
+        )}
+
         {finished && (
           <div className="mt-4 flex justify-end">
             <button className="px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500" onClick={onFinish}>


### PR DESCRIPTION
## Summary
- auto-open combat summary with fake lines via debug effect
- show tap-friendly ghost continue prompt

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c0f55a302c8325bada325b04d277a9