### PR TITLE
feat(core): coherence patch — set global day to 24h, add escape cost, fix healing validation, consistent combat logs & loot, interactive exploration notes, and realistic repair times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Coherence Patch (24h day)
+- Set global day duration to 24 real-time hours.
+- Added central time configuration module with unified constants and migration flag.
+- Escape from combat now costs 45 minutes and may inflict minor wounds.
+- Healing is blocked when at full HP and always consumes meaningful time.
+- Combat log entries now include an in-game timestamp.

--- a/src/config/time.ts
+++ b/src/config/time.ts
@@ -1,0 +1,29 @@
+/**
+ * Global time configuration for the 24h coherence patch.
+ * All durations are expressed in seconds unless stated otherwise.
+ */
+export const COHERENCE_PATCH_2025_09 = true;
+
+export const HOURS_PER_DAY = 24;
+export const MINUTES_PER_HOUR = 60;
+export const SECONDS_PER_MINUTE = 60;
+export const SECONDS_PER_DAY = HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE; // 86400
+export const DAY_LENGTH_MS = SECONDS_PER_DAY * 1000;
+
+// Default tick interval for timers that operate in real time
+export const DEFAULT_TICK_MS = 1000; // 1 second per tick for clarity
+
+// Action time costs in seconds
+export const ACTION_TIME_COSTS = {
+  explore: 60 * 60,      // 1 hour
+  battle: 60,            // 1 minute per combat action
+  decision: 5 * 60,      // 5 minutes per decision
+  heal: 10 * 60,         // 10 minutes to heal
+  defend: 60,            // 1 minute to defend
+  flee: 45 * 60,         // 45 minutes to flee combat
+} as const;
+
+// Helper converting action costs to milliseconds
+export const ACTION_TIME_COSTS_MS: Record<keyof typeof ACTION_TIME_COSTS, number> = Object.fromEntries(
+  Object.entries(ACTION_TIME_COSTS).map(([k,v]) => [k, v * 1000])
+) as any;

--- a/src/systems/time.ts
+++ b/src/systems/time.ts
@@ -5,20 +5,13 @@ export type TimeState = {
   tickIntervalMs: number;
 };
 
-export const DAY_LENGTH_MINUTES = 20;
-export const DEFAULT_TICK_MS = 500;
-
-export const ACTION_TIME_COSTS = {
-  explore: 30_000,
-  battle: 20_000,
-  decision: 10_000,
-};
+import { DAY_LENGTH_MS, DEFAULT_TICK_MS, ACTION_TIME_COSTS_MS } from "../config/time";
 
 export function createTimeState(): TimeState {
   return {
     day: 1,
-    dayClockMs: DAY_LENGTH_MINUTES * 60_000,
-    dayLengthMs: DAY_LENGTH_MINUTES * 60_000,
+    dayClockMs: DAY_LENGTH_MS,
+    dayLengthMs: DAY_LENGTH_MS,
     tickIntervalMs: DEFAULT_TICK_MS,
   };
 }
@@ -27,8 +20,8 @@ export function tickTime(state: TimeState) {
   state.dayClockMs = Math.max(0, state.dayClockMs - state.tickIntervalMs);
 }
 
-export function applyTimeCost(state: TimeState, kind: keyof typeof ACTION_TIME_COSTS) {
-  state.dayClockMs = Math.max(0, state.dayClockMs - ACTION_TIME_COSTS[kind]);
+export function applyTimeCost(state: TimeState, kind: keyof typeof ACTION_TIME_COSTS_MS) {
+  state.dayClockMs = Math.max(0, state.dayClockMs - ACTION_TIME_COSTS_MS[kind]);
 }
 
 export function shouldAdvanceDay(state: TimeState) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,8 @@
 export type LogFn = (msg: string) => void;
+export type TimeFn = () => string;
 
 let currentLogger: LogFn = () => {};
+let timeProvider: TimeFn = () => "??:??";
 /**
  * Registra la función que empuja logs al estado de la app.
  * Se puede llamar múltiples veces; siempre usaremos la última.
@@ -10,12 +12,20 @@ export function registerLogger(fn: LogFn) {
 }
 
 /**
+ * Registra una función que devuelve la hora actual en formato HH:MM.
+ */
+export function registerTimeProvider(fn: TimeFn) {
+  timeProvider = fn;
+}
+
+/**
  * Publica un log de juego de forma segura.
  * Nunca lanza, aunque no haya logger registrado aún.
  */
 export function gameLog(message: string) {
   try {
-    currentLogger(message);
+    const stamp = timeProvider();
+    currentLogger(`[${stamp}] ${message}`);
   } catch {
     // no-op para no romper el runtime
   }


### PR DESCRIPTION
## Summary
- centralize time settings into config/time with 24h day
- timestamped game log and time-aware HUD
- fleeing and healing now consume realistic time and validate HP

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c0fc7a5a1883259f19182862947054