### PR TITLE
feat(combat): sistema de turnos por rondas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
+build
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@
 - Escape from combat now costs 45 minutes and may inflict minor wounds.
 - Healing is blocked when at full HP and always consumes meaningful time.
 - Combat log entries now include an in-game timestamp.
+
+## Turn-based combat rounds
+- Added round system: the team acts in fixed order (Sarah → Marcus → Elena) before enemy turns determined by a dice roll.
+- After battle, surviving allies return to a ready state with minimal HP and energy.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Pasar la noche resuelve amenazas y avanza el día.
 - Narrativa contextual en el registro.
 - Citas de filósofos en el HUD.
+- Combate por rondas: Sarah → Marcus → Elena seguidos por turnos enemigos determinados por tirada.
 
 ## Dev
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsc src/engine/turns.ts src/systems/combat.ts --module node16 --target ES2020 --moduleResolution node16 --skipLibCheck --outDir build && node --test tests/turns.test.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/engine/turns.ts
+++ b/src/engine/turns.ts
@@ -1,0 +1,103 @@
+import { CombatActor, isAlive } from "../systems/combat.js";
+import { ACTION_TIME_COSTS } from "../config/time.js";
+
+export interface RNG {
+  int: (max: number) => number; // 0..max-1
+}
+
+export interface Ally extends CombatActor {
+  status?: string;
+  energy: number;
+}
+
+export type Enemy = CombatActor;
+
+export interface CombatContext {
+  allies: Ally[];
+  enemies: Enemy[];
+  rng: RNG;
+  log: (msg: string) => void;
+  now: () => string;
+  allyAct: (ctx: CombatContext, ally: Ally) => Promise<void> | void;
+  enemyAct: (ctx: CombatContext, enemy: Enemy) => Promise<void> | void;
+  applyTimeCost?: (seconds: number) => void;
+}
+
+export const ENEMY_TURNS_ROLL_SIDES = 2;
+export const POST_COMBAT_MIN_HP = 1;
+export const POST_COMBAT_MIN_ENERGY = 1;
+
+export async function runBattleRound(ctx: CombatContext) {
+  await runAlliesPhase(ctx);
+  const nEnemyTurns = rollEnemyTurns(ctx);
+  await runEnemiesPhase(ctx, nEnemyTurns);
+  ctx.applyTimeCost?.(ACTION_TIME_COSTS.battle);
+  ctx.log(`[${ctx.now()}] Fin de ronda.`);
+}
+
+export async function runFullBattle(ctx: CombatContext) {
+  ctx.log(`[${ctx.now()}] Comienza el turno de tu equipo…`);
+  while (!allEnemiesDead(ctx) && !allAlliesDown(ctx)) {
+    await runBattleRound(ctx);
+    if (allEnemiesDead(ctx) || allAlliesDown(ctx)) break;
+    ctx.log(`[${ctx.now()}] Terminan los turnos de tu equipo: Sarah → Marcus → Elena. Ahora atacan los enemigos…`);
+    ctx.log(`[${ctx.now()}] Comienza el turno de tu equipo…`);
+  }
+  showBattleSummary(ctx);
+  applyPostCombat(ctx);
+}
+
+async function runAlliesPhase(ctx: CombatContext) {
+  const order = ["Sarah", "Marcus", "Elena"];
+  for (const name of order) {
+    const ally = findAliveAlly(ctx, name);
+    if (!ally) continue;
+    await ctx.allyAct(ctx, ally);
+    if (allEnemiesDead(ctx)) break;
+  }
+}
+
+export function rollEnemyTurns(ctx: CombatContext): number {
+  return 1 + ctx.rng.int(ENEMY_TURNS_ROLL_SIDES);
+}
+
+async function runEnemiesPhase(ctx: CombatContext, n: number) {
+  for (let i = 0; i < n; i++) {
+    ctx.log(`[${ctx.now()}] Turno enemigo ${i + 1}/${n}.`);
+    for (const enemy of getAliveEnemies(ctx)) {
+      await ctx.enemyAct(ctx, enemy);
+      if (allAlliesDown(ctx)) break;
+    }
+    if (allAlliesDown(ctx) || allEnemiesDead(ctx)) break;
+  }
+}
+
+function getAliveEnemies(ctx: CombatContext) {
+  return ctx.enemies.filter(isAlive);
+}
+
+function findAliveAlly(ctx: CombatContext, name: string) {
+  return ctx.allies.find(a => a.name === name && isAlive(a));
+}
+
+function allEnemiesDead(ctx: CombatContext) {
+  return ctx.enemies.every(e => !isAlive(e));
+}
+
+function allAlliesDown(ctx: CombatContext) {
+  return ctx.allies.every(a => !isAlive(a));
+}
+
+function showBattleSummary(ctx: CombatContext) {
+  ctx.log(`[${ctx.now()}] Fin del combate.`);
+}
+
+export function applyPostCombat(ctx: CombatContext) {
+  for (const a of ctx.allies) {
+    if (a.hp > 0) {
+      a.status = "ready";
+      a.hp = POST_COMBAT_MIN_HP;
+      a.energy = POST_COMBAT_MIN_ENERGY;
+    }
+  }
+}

--- a/tests/turns.test.mjs
+++ b/tests/turns.test.mjs
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  runBattleRound,
+  rollEnemyTurns,
+  applyPostCombat,
+  runFullBattle,
+  ENEMY_TURNS_ROLL_SIDES,
+  POST_COMBAT_MIN_HP,
+  POST_COMBAT_MIN_ENERGY,
+} from '../build/engine/turns.js';
+
+function createCtx(overrides) {
+  const base = {
+    allies: [],
+    enemies: [],
+    rng: { int: () => 0 },
+    log: () => {},
+    now: () => '00:00',
+    allyAct: async () => {},
+    enemyAct: async () => {},
+  };
+  return Object.assign(base, overrides);
+}
+
+test('enemy turn roll respects sides', () => {
+  const ctx1 = createCtx({ rng: { int: () => 0 } });
+  assert.equal(rollEnemyTurns(ctx1), 1);
+  const ctx2 = createCtx({ rng: { int: () => ENEMY_TURNS_ROLL_SIDES - 1 } });
+  assert.equal(rollEnemyTurns(ctx2), ENEMY_TURNS_ROLL_SIDES);
+});
+
+test('allies act in fixed order skipping dead', async () => {
+  const order = [];
+  const enemies = [{ id: 'e1', name: 'Z', hp: 3, maxHp: 3, baseCooldownMs: 0, actionCooldownMs: 0 }];
+  const allies = [
+    { id: 's', name: 'Sarah', hp: 1, maxHp: 1, baseCooldownMs: 0, actionCooldownMs: 0, energy: 1 },
+    { id: 'm', name: 'Marcus', hp: 0, maxHp: 1, baseCooldownMs: 0, actionCooldownMs: 0, energy: 1 },
+    { id: 'e', name: 'Elena', hp: 1, maxHp: 1, baseCooldownMs: 0, actionCooldownMs: 0, energy: 1 },
+  ];
+  const ctx = createCtx({ allies, enemies, allyAct: async (c, a) => { order.push(a.name); }, rng: { int: () => 0 } });
+  await runBattleRound(ctx);
+  assert.deepEqual(order, ['Sarah', 'Elena']);
+});
+
+test('post combat sets survivors to min values and ready', () => {
+  const allies = [
+    { id: 's', name: 'Sarah', hp: 5, maxHp: 5, baseCooldownMs: 0, actionCooldownMs: 0, energy: 10, status: 'down' },
+    { id: 'm', name: 'Marcus', hp: 0, maxHp: 5, baseCooldownMs: 0, actionCooldownMs: 0, energy: 0, status: 'dead' },
+  ];
+  const ctx = createCtx({ allies });
+  applyPostCombat(ctx);
+  assert.equal(allies[0].status, 'ready');
+  assert.equal(allies[0].hp, POST_COMBAT_MIN_HP);
+  assert.equal(allies[0].energy, POST_COMBAT_MIN_ENERGY);
+  assert.equal(allies[1].status, 'dead');
+});
+
+test('full battle ends when enemies dead', async () => {
+  const allies = [{ id: 's', name: 'Sarah', hp: 2, maxHp: 2, baseCooldownMs: 0, actionCooldownMs: 0, energy: 2 }];
+  const enemies = [{ id: 'e1', name: 'Z', hp: 1, maxHp: 1, baseCooldownMs: 0, actionCooldownMs: 0 }];
+  const ctx = createCtx({ allies, enemies, allyAct: async (c, a) => { c.enemies[0].hp = 0; }, enemyAct: async () => {}, rng: { int: () => 0 } });
+  await runFullBattle(ctx);
+  assert.equal(enemies[0].hp, 0);
+  assert.equal(allies[0].hp, POST_COMBAT_MIN_HP);
+});
+
+test('full battle ends when allies down', async () => {
+  const allies = [{ id: 's', name: 'Sarah', hp: 1, maxHp: 1, baseCooldownMs: 0, actionCooldownMs: 0, energy: 1 }];
+  const enemies = [{ id: 'e1', name: 'Z', hp: 3, maxHp: 3, baseCooldownMs: 0, actionCooldownMs: 0 }];
+  const ctx = createCtx({ allies, enemies, allyAct: async () => {}, enemyAct: async (c, e) => { c.allies[0].hp = 0; }, rng: { int: () => 0 } });
+  await runFullBattle(ctx);
+  assert.equal(allies[0].hp, 0);
+});


### PR DESCRIPTION
## Summary
- add turn-based battle controller with ally fixed order and enemy turn rolls
- enforce post-combat ready state with minimal HP and energy
- document round system and add tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ff667154832587767d62e74cd34b