### PR TITLE
fix(combat): use equipped weapon and restore enemy turns

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -97,6 +97,7 @@ type Player = {
   attrs: Attributes;
   conditions?: Conditions;
   selectedWeaponId?: string;
+  currentWeaponId?: string;
   ammoByWeapon?: Record<string, number>;
   backpackCapacity?: number;
 };
@@ -311,6 +312,7 @@ export default function App(){
       energy: p.energy ?? 100,
       energyMax: p.energyMax ?? 100,
       selectedWeaponId: p.selectedWeaponId ?? "fists",
+      currentWeaponId: p.currentWeaponId ?? p.selectedWeaponId ?? "fists",
       ammoByWeapon: table,
       backpack: Array.isArray((p as any).backpack) ? (p as any).backpack : [],
       inventory: Array.isArray((p as any).inventory) ? (p as any).inventory : [],
@@ -473,7 +475,7 @@ export default function App(){
     const list: {id:string; name:string}[] = [];
     const add = (id:string, name:string) => { if(!list.find(w=>w.id===id)) list.push({id,name}); };
 
-    const selId = (player as any)?.selectedWeaponId;
+    const selId = (player as any)?.currentWeaponId ?? (player as any)?.selectedWeaponId;
     const byId = selId ? WEAPONS.find(w => w.id === selId) : null;
     if (byId && byId.type === "ranged") add(byId.id, byId.name);
 
@@ -587,7 +589,7 @@ export default function App(){
       table[weaponId] = Math.max(0, Number(table[weaponId] ?? 0)) + taken;
 
       pushLog?.(`🔧 Recargas ${taken} munición(es) en ${weaponId}.`);
-      return { ...p, inventory: a.out, backpack: b.out, ammoByWeapon: table, selectedWeaponId: weaponId };
+      return { ...p, inventory: a.out, backpack: b.out, ammoByWeapon: table, selectedWeaponId: weaponId, currentWeaponId: weaponId };
     }));
     setShowReloadModal(false);
 
@@ -789,6 +791,7 @@ export default function App(){
       conditions: {},
       attrs,
       selectedWeaponId: 'fists',
+      currentWeaponId: 'fists',
       ammoByWeapon: {},
       backpackCapacity: 8,
     };
@@ -1101,7 +1104,7 @@ export default function App(){
   function performAttack(enemyId: string){
     if (controlsLocked || isEnemyPhase) return;
     const player = players.find(pl => pl.id === activePlayerId);
-    const wid = player?.selectedWeaponId;
+    const wid = player?.currentWeaponId ?? player?.selectedWeaponId;
     const ammoLoaded = Number(player?.ammoByWeapon?.[wid ?? ""] ?? 0);
     const ranged = WEAPONS.find(x => x.id === wid)?.type === "ranged";
     const targetName = enemies.find(e=>e.id===enemyId)?.name ?? (enemies && enemies.length ? (enemies[0].name ?? "el enemigo") : "el enemigo");
@@ -1730,8 +1733,8 @@ function advanceTurn() {
     }
   }
 
-  function setPlayerSelectedWeapon(playerId: string, weaponId: string) {
-    updatePlayer(playerId, { selectedWeaponId: weaponId });
+  function equipWeapon(playerId: string, weaponId: string) {
+    updatePlayer(playerId, { selectedWeaponId: weaponId, currentWeaponId: weaponId });
   }
   function backpackWeapons(p: Player) {
     return p.inventory
@@ -2178,7 +2181,7 @@ function advanceTurn() {
           <WeaponPicker
             player={activePlayer}
             backpack={backpackWeapons(activePlayer)}
-            onSelect={(wid) => setPlayerSelectedWeapon(activePlayer.id, wid)}
+            onSelect={(wid) => equipWeapon(activePlayer.id, wid)}
           />
         )}
         <CombatLogPanel
@@ -2720,7 +2723,7 @@ function PartyPanel({players, onUpdatePlayer, onRemove, activePlayerId, isEnemyP
               const weaponsFound: {id:string; name:string}[] = [];
               const addW = (id:string, name:string) => { if(!weaponsFound.find(w=>w.id===id)) weaponsFound.push({id,name}); };
 
-              const selId = (p as any)?.selectedWeaponId;
+              const selId = (p as any)?.currentWeaponId ?? (p as any)?.selectedWeaponId;
               const sel = selId ? WEAPONS.find(w => w.id === selId) : null;
               if (sel && sel.type === "ranged") addW(sel.id, sel.name);
 

--- a/components/WeaponPicker.tsx
+++ b/components/WeaponPicker.tsx
@@ -41,12 +41,14 @@ export default function WeaponPicker({ player, backpack, onSelect }: WeaponPicke
           return (
             <button
               key={w.id}
+              disabled={noAmmo}
               onClick={() => onSelect(w.id)}
               className={[
                 "relative text-left p-2 rounded-xl border transition",
                 selected ? "border-indigo-400 bg-indigo-500/10" : "border-white/10 hover:border-white/20",
-                noAmmo ? "opacity-60" : ""
+                noAmmo ? "opacity-60 cursor-not-allowed" : ""
               ].join(" ")}
+              title={noAmmo ? "Sin munición" : undefined}
             >
               <div className="font-medium">
                 {w.name}

--- a/components/overlays/AmmoReloadModal.tsx
+++ b/components/overlays/AmmoReloadModal.tsx
@@ -60,7 +60,7 @@ function listReloadableWeapons(player:any): Weapon[] {
   const list: Weapon[] = [];
   const add = (id:string, name:string) => { if(!list.find(w=>w.id===id)) list.push({id,name}); };
 
-  const selId = (player as any)?.selectedWeaponId;
+  const selId = (player as any)?.currentWeaponId ?? (player as any)?.selectedWeaponId;
   const byId = selId ? WEAPONS.find(w => w.id === selId) : null;
   if (byId && byId.type === "ranged") add(byId.id, byId.name);
 

--- a/helpers.ts
+++ b/helpers.ts
@@ -126,7 +126,7 @@ export function listReloadableWeapons(player:any): {id:string; name:string}[] {
   const normalize = (s?:string)=>String(s||"").normalize("NFD").replace(/\p{Diacritic}/gu,"").toLowerCase();
 
   // 1) arma seleccionada si es de fuego (por id del catálogo o por getter)
-  const selId = (player as any)?.selectedWeaponId;
+  const selId = (player as any)?.currentWeaponId ?? (player as any)?.selectedWeaponId;
   const byId = selId ? WEAPONS.find(w => w.id === selId) : null;
   const fromGetter = typeof getSelectedWeapon === "function" ? getSelectedWeapon(player) : null;
   const selectedRanged = byId?.type === "ranged" ? byId

--- a/src/components/overlays/AmmoReloadModal.tsx
+++ b/src/components/overlays/AmmoReloadModal.tsx
@@ -60,7 +60,7 @@ function listReloadableWeapons(player:any): Weapon[] {
   const list: Weapon[] = [];
   const add = (id:string, name:string) => { if(!list.find(w=>w.id===id)) list.push({id,name}); };
 
-  const selId = (player as any)?.selectedWeaponId;
+  const selId = (player as any)?.currentWeaponId ?? (player as any)?.selectedWeaponId;
   const byId = selId ? WEAPONS.find(w => w.id === selId) : null;
   if (byId && byId.type === "ranged") add(byId.id, byId.name);
 

--- a/src/engine/turns.ts
+++ b/src/engine/turns.ts
@@ -29,6 +29,8 @@ export const POST_COMBAT_MIN_ENERGY = 1;
 
 export async function runBattleRound(ctx: CombatContext) {
   await runAlliesPhase(ctx);
+  if (allEnemiesDead(ctx) || allAlliesDown(ctx)) return;
+  ctx.log(`[${ctx.now()}] Terminan los turnos de tu equipo: Sarah → Marcus → Elena. Ahora atacan los enemigos…`);
   const nEnemyTurns = rollEnemyTurns(ctx);
   await runEnemiesPhase(ctx, nEnemyTurns);
   ctx.applyTimeCost?.(ACTION_TIME_COSTS.battle);
@@ -40,7 +42,6 @@ export async function runFullBattle(ctx: CombatContext) {
   while (!allEnemiesDead(ctx) && !allAlliesDown(ctx)) {
     await runBattleRound(ctx);
     if (allEnemiesDead(ctx) || allAlliesDown(ctx)) break;
-    ctx.log(`[${ctx.now()}] Terminan los turnos de tu equipo: Sarah → Marcus → Elena. Ahora atacan los enemigos…`);
     ctx.log(`[${ctx.now()}] Comienza el turno de tu equipo…`);
   }
   showBattleSummary(ctx);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -126,7 +126,7 @@ export function listReloadableWeapons(player:any): {id:string; name:string}[] {
   const normalize = (s?:string)=>String(s||"").normalize("NFD").replace(/\p{Diacritic}/gu,"").toLowerCase();
 
   // 1) arma seleccionada si es de fuego (por id del catálogo o por getter)
-  const selId = (player as any)?.selectedWeaponId;
+  const selId = (player as any)?.currentWeaponId ?? (player as any)?.selectedWeaponId;
   const byId = selId ? WEAPONS.find(w => w.id === selId) : null;
   const fromGetter = typeof getSelectedWeapon === "function" ? getSelectedWeapon(player) : null;
   const selectedRanged = byId?.type === "ranged" ? byId

--- a/src/systems/weapons.ts
+++ b/src/systems/weapons.ts
@@ -18,7 +18,7 @@ export const FISTS_WEAPON = {
  */
 export function getSelectedWeapon(player: any) {
   try {
-    const selId = player?.selectedWeaponId;
+    const selId = player?.currentWeaponId ?? player?.selectedWeaponId;
     if (selId) {
       const w = findWeaponById(selId);
       if (w) {

--- a/systems/weapons.ts
+++ b/systems/weapons.ts
@@ -18,7 +18,7 @@ export const FISTS_WEAPON = {
  */
 export function getSelectedWeapon(player: any) {
   try {
-    const selId = player?.selectedWeaponId;
+    const selId = player?.currentWeaponId ?? player?.selectedWeaponId;
     if (selId) {
       const w = findWeaponById(selId);
       if (w) {


### PR DESCRIPTION
## Summary
- track each character's equipped weapon and always use it for damage
- disable weapon selection when out of ammo
- run enemy phases after allies with proper logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c10c7ed65883258baa7d3e500310b4