### PR TITLE
feat: weapon aliases and phased turns

### DIFF
--- a/src/systems/combat/getAvailableWeapons.ts
+++ b/src/systems/combat/getAvailableWeapons.ts
@@ -5,40 +5,78 @@ export type WeaponOpt = { id: string; label: string; usable: boolean; reason?: s
 
 type Player = { inventory?: any[]; ammo?: number };
 
-/** Comprueba si el jugador porta un item de cierto tipo */
-function hasItem(p: Player, type: string): boolean {
-  return Array.isArray(p.inventory) && p.inventory.some((i: any) => {
-    if (typeof i === "string") return i === type;
-    return i?.type === type || i?.id === type || i?.name === type;
+/** Normaliza a minúsculas, sin tildes y con espacios colapsados */
+function norm(s?: string) {
+  return String(s ?? "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Alias ES → categoría canónica que usa el sistema de combate */
+const ALIAS: Record<string, string[]> = {
+  knife: ["knife","navaja","cuchillo","cuchillo tactico","kukri","tacdag","daga"],
+  pistol: ["pistol","pistola","pistola 9mm","pistola9","revolver",".38","38"],
+  rifle: ["rifle","rifle de caza","rifle_caza","rifle asalto","rifle_asalto","francotirador"],
+  shotgun: ["escopeta","shotgun"],
+  smg: ["smg","subfusil","subfusil (smg)"],
+};
+
+/** ¿El inventario contiene alguno de los alias dados? */
+function hasAny(p: Player, keys: string[]): boolean {
+  if (!Array.isArray(p.inventory)) return false;
+  return p.inventory.some((i: any) => {
+    const idOrName = typeof i === "string" ? i : (i?.id ?? i?.type ?? i?.name);
+    const token = norm(idOrName);
+    return keys.some(k => token.includes(norm(k)));
   });
 }
 
 export function getAvailableWeapons(player: Player): WeaponOpt[] {
-  const list: WeaponOpt[] = [
-    { id: 'fists', label: 'Puños (1–2)', usable: true },
-  ];
+  const list: WeaponOpt[] = [{ id: "fists", label: "Puños (1–2)", usable: true }];
 
-  if (hasItem(player, 'knife')) {
-    list.push({ id: 'knife', label: 'Navaja (1–6)', usable: true });
+  if (hasAny(player, ALIAS.knife)) {
+    list.push({ id: "knife", label: "Navaja (1–6)", usable: true });
   }
 
   const ammo = player.ammo ?? 0;
 
-  if (hasItem(player, 'pistol')) {
+  if (hasAny(player, ALIAS.pistol)) {
     list.push({
-      id: 'pistol',
+      id: "pistol",
       label: `Pistola (2–8) — Munición: ${ammo}`,
       usable: ammo > 0,
-      reason: ammo > 0 ? undefined : 'Sin munición',
+      reason: ammo > 0 ? undefined : "Sin munición",
     });
   }
 
-  if (hasItem(player, 'rifle')) {
+  if (hasAny(player, ALIAS.rifle)) {
     list.push({
-      id: 'rifle',
+      id: "rifle",
       label: `Rifle (4–12) — Munición: ${ammo}`,
       usable: ammo > 0,
-      reason: ammo > 0 ? undefined : 'Sin munición',
+      reason: ammo > 0 ? undefined : "Sin munición",
+    });
+  }
+
+  // Opcionales si tu UI los usa:
+  if (hasAny(player, ALIAS.shotgun)) {
+    list.push({
+      id: "shotgun",
+      label: `Escopeta (2d4+3) — Munición: ${ammo}`,
+      usable: ammo > 0,
+      reason: ammo > 0 ? undefined : "Sin munición",
+    });
+  }
+
+  if (hasAny(player, ALIAS.smg)) {
+    list.push({
+      id: "smg",
+      label: `SMG (1d6+3) — Munición: ${ammo}`,
+      usable: ammo > 0,
+      reason: ammo > 0 ? undefined : "Sin munición",
     });
   }
 

--- a/src/systems/turns.ts
+++ b/src/systems/turns.ts
@@ -14,18 +14,73 @@ export type TurnState = {
   activeIndex: number;
   turnNumber: number;
   overlay: boolean;
+  phase: 'player' | 'enemy';
 };
 
 export function createTurnState(): TurnState {
-  return { activeIndex: 0, turnNumber: 1, overlay: true };
+  return { activeIndex: 0, turnNumber: 1, overlay: true, phase: 'player' };
+}
+
+/**
+ * Avanza el turno por fases:
+ * - player: recorre jugadores; al terminar → enemy (activeIndex=0)
+ * - enemy:  recorre enemigos; al terminar → player (activeIndex=0, turnNumber++)
+ */
+export function nextTurn(turn: TurnState, playersLen: number, enemiesLen: number) {
+  // Guardas por si se pasa 0 o negativos
+  const pLen = Math.max(0, playersLen|0);
+  const eLen = Math.max(0, enemiesLen|0);
+
+  if (turn.phase === 'player') {
+    // Si no hay jugadores, salta directo a enemigos
+    if (pLen === 0) {
+      turn.phase = 'enemy';
+      turn.activeIndex = 0;
+      turn.overlay = true;
+      return;
+    }
+    turn.activeIndex++;
+    if (turn.activeIndex >= pLen) {
+      turn.phase = 'enemy';
+      turn.activeIndex = 0;
+    }
+    turn.overlay = true;
+    return;
+  }
+
+  // Fase 'enemy'
+  if (eLen === 0) {
+    // Si no hay enemigos, vuelve a jugadores nueva ronda
+    turn.phase = 'player';
+    turn.activeIndex = 0;
+    turn.turnNumber += 1;
+    turn.overlay = true;
+    return;
+  }
+
+  turn.activeIndex++;
+  if (turn.activeIndex >= eLen) {
+    turn.phase = 'player';
+    turn.activeIndex = 0;
+    turn.turnNumber += 1;
+  }
+  turn.overlay = true;
+}
+
+/** Opcional: wrapper deprecado para compatibilidad; usar nextTurn en adelante */
+export function nextPlayer(turn: TurnState, playersLen: number) {
+  if (process && typeof console !== 'undefined') {
+    console.warn('[DEPRECATION] nextPlayer() -> usa nextTurn(turn, playersLen, enemiesLen).');
+  }
+  // Comportamiento mínimo: avanza jugadores; si termina, pasa a fase enemigos.
+  turn.activeIndex = (turn.activeIndex + 1) % Math.max(1, playersLen|0);
+  if (turn.activeIndex === 0) {
+    turn.phase = 'enemy';
+  }
+  turn.overlay = true;
 }
 
 export function resetCupos(): PlayerCupos {
   return { ...DEFAULT_CUPOS };
 }
 
-export function nextPlayer(turn: TurnState, playersLen: number) {
-  turn.activeIndex = (turn.activeIndex + 1) % playersLen;
-  if (turn.activeIndex === 0) turn.turnNumber += 1;
-  turn.overlay = true;
-}

--- a/systems/turns.ts
+++ b/systems/turns.ts
@@ -14,18 +14,73 @@ export type TurnState = {
   activeIndex: number;
   turnNumber: number;
   overlay: boolean;
+  phase: 'player' | 'enemy';
 };
 
 export function createTurnState(): TurnState {
-  return { activeIndex: 0, turnNumber: 1, overlay: true };
+  return { activeIndex: 0, turnNumber: 1, overlay: true, phase: 'player' };
+}
+
+/**
+ * Avanza el turno por fases:
+ * - player: recorre jugadores; al terminar → enemy (activeIndex=0)
+ * - enemy:  recorre enemigos; al terminar → player (activeIndex=0, turnNumber++)
+ */
+export function nextTurn(turn: TurnState, playersLen: number, enemiesLen: number) {
+  // Guardas por si se pasa 0 o negativos
+  const pLen = Math.max(0, playersLen|0);
+  const eLen = Math.max(0, enemiesLen|0);
+
+  if (turn.phase === 'player') {
+    // Si no hay jugadores, salta directo a enemigos
+    if (pLen === 0) {
+      turn.phase = 'enemy';
+      turn.activeIndex = 0;
+      turn.overlay = true;
+      return;
+    }
+    turn.activeIndex++;
+    if (turn.activeIndex >= pLen) {
+      turn.phase = 'enemy';
+      turn.activeIndex = 0;
+    }
+    turn.overlay = true;
+    return;
+  }
+
+  // Fase 'enemy'
+  if (eLen === 0) {
+    // Si no hay enemigos, vuelve a jugadores nueva ronda
+    turn.phase = 'player';
+    turn.activeIndex = 0;
+    turn.turnNumber += 1;
+    turn.overlay = true;
+    return;
+  }
+
+  turn.activeIndex++;
+  if (turn.activeIndex >= eLen) {
+    turn.phase = 'player';
+    turn.activeIndex = 0;
+    turn.turnNumber += 1;
+  }
+  turn.overlay = true;
+}
+
+/** Opcional: wrapper deprecado para compatibilidad; usar nextTurn en adelante */
+export function nextPlayer(turn: TurnState, playersLen: number) {
+  if (process && typeof console !== 'undefined') {
+    console.warn('[DEPRECATION] nextPlayer() -> usa nextTurn(turn, playersLen, enemiesLen).');
+  }
+  // Comportamiento mínimo: avanza jugadores; si termina, pasa a fase enemigos.
+  turn.activeIndex = (turn.activeIndex + 1) % Math.max(1, playersLen|0);
+  if (turn.activeIndex === 0) {
+    turn.phase = 'enemy';
+  }
+  turn.overlay = true;
 }
 
 export function resetCupos(): PlayerCupos {
   return { ...DEFAULT_CUPOS };
 }
 
-export function nextPlayer(turn: TurnState, playersLen: number) {
-  turn.activeIndex = (turn.activeIndex + 1) % playersLen;
-  if (turn.activeIndex === 0) turn.turnNumber += 1;
-  turn.overlay = true;
-}


### PR DESCRIPTION
## Summary
- normalize inventory ids and support Spanish weapon aliases in `getAvailableWeapons`
- introduce phased player/enemy turns with `nextTurn`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c178e29950832585c6afc71d588914