### PR TITLE
feat: add ammo stacking and reload mechanics

### DIFF
--- a/src/components/Combat/ActionBar.tsx
+++ b/src/components/Combat/ActionBar.tsx
@@ -9,6 +9,7 @@ interface Props {
   flee: () => void;
   selfHeal: () => void;
   doAttack: (weaponId: string) => void;
+  reload: () => void;
 }
 
 export default function ActionBar({
@@ -17,6 +18,7 @@ export default function ActionBar({
   flee,
   selfHeal,
   doAttack,
+  reload,
 }: Props) {
   const canFlee = useMemo(() => {
     if (player.isGrappled) return { ok: false, reason: "Estás atrapado" };
@@ -50,6 +52,12 @@ export default function ActionBar({
           onClick={() => doAttack(selected)}
         >
           Atacar
+        </button>
+        <button
+          className="mt-1 px-3 py-1 rounded bg-neutral-700 text-white"
+          onClick={() => reload()}
+        >
+          Recargar
         </button>
       </div>
 

--- a/src/components/combat/AttackFlow.tsx
+++ b/src/components/combat/AttackFlow.tsx
@@ -33,6 +33,13 @@ export function performAttack(
   }
 
   const next = resolveAttack(state, weapon.id, { name: player.name || "Alguien" });
+  const nextPlayer = next.players?.[turn.activeIndex];
+  if (isRangedWeapon(weapon) && nextPlayer) {
+    const ws = { ...(nextPlayer.weaponState ?? {}) };
+    const cur = ws[weapon.id]?.ammoInMag ?? ammo;
+    ws[weapon.id] = { ammoInMag: Math.max(0, cur - 1) };
+    nextPlayer.weaponState = ws;
+  }
   nextTurn(turn, playersLen, enemiesLen);
   return next;
 }

--- a/src/data/weapons.ts
+++ b/src/data/weapons.ts
@@ -6,6 +6,8 @@ export type Weapon = {
   damage: { times: number; faces: number; mod: number };
   usesAttr: 'Fuerza'|'Destreza';
   ammoCost?: number;
+  magCapacity?: number;
+  ammoType?: '9mm'|'rifle'|'12g'|'smg'|null;
 };
 
 export const WEAPONS: Weapon[] = [
@@ -36,10 +38,10 @@ export const WEAPONS: Weapon[] = [
 
   { id:'sling',  name:'Hondita',           type:'ranged', hitBonus:1, damage:{times:1,faces:4,mod:1},  usesAttr:'Destreza', ammoCost:0 },
   { id:'xbow',   name:'Ballesta',          type:'ranged', hitBonus:3, damage:{times:1,faces:8,mod:2},  usesAttr:'Destreza', ammoCost:1 },
-  { id:'pistol', name:'Pistola',           type:'ranged', hitBonus:4, damage:{times:1,faces:6,mod:4},  usesAttr:'Destreza', ammoCost:1 },
-  { id:'rifle',  name:'Rifle',             type:'ranged', hitBonus:5, damage:{times:1,faces:8,mod:4},  usesAttr:'Destreza', ammoCost:1 },
-  { id:'shotgun',name:'Escopeta',          type:'ranged', hitBonus:3, damage:{times:2,faces:4,mod:3},  usesAttr:'Destreza', ammoCost:1 },
-  { id:'smg',    name:'Subfusil (SMG)',    type:'ranged', hitBonus:5, damage:{times:1,faces:6,mod:3},  usesAttr:'Destreza', ammoCost:1 },
+  { id:'pistol', name:'Pistola',           type:'ranged', hitBonus:4, damage:{times:1,faces:6,mod:4},  usesAttr:'Destreza', ammoCost:1, magCapacity:15, ammoType:'9mm' },
+  { id:'rifle',  name:'Rifle',             type:'ranged', hitBonus:5, damage:{times:1,faces:8,mod:4},  usesAttr:'Destreza', ammoCost:1, magCapacity:10, ammoType:'rifle' },
+  { id:'shotgun',name:'Escopeta',          type:'ranged', hitBonus:3, damage:{times:2,faces:4,mod:3},  usesAttr:'Destreza', ammoCost:1, magCapacity:6, ammoType:'12g' },
+  { id:'smg',    name:'Subfusil (SMG)',    type:'ranged', hitBonus:5, damage:{times:1,faces:6,mod:3},  usesAttr:'Destreza', ammoCost:1, magCapacity:30, ammoType:'smg' },
 ];
 
 export function findWeaponById(id?: string) {

--- a/src/state/loot.ts
+++ b/src/state/loot.ts
@@ -1,0 +1,25 @@
+import { InventoryItem, addAmmo, normalizeAmmo } from "../systems/ammo";
+import { gameLog } from "../utils/logger";
+
+/**
+ * Añade botín de munición al inventario del jugador.
+ * - ammo: balas sueltas
+ * - box: si es true, agrega una caja de 15 balas
+ */
+export function applyAmmoLoot(
+  inventory: InventoryItem[],
+  loot: { ammo?: number; box?: boolean }
+): InventoryItem[] {
+  let inv = [...(inventory ?? [])];
+  if (loot.box) {
+    inv.push({ name: "Caja de munición", ammo: { type: "box", count: 15 } });
+    gameLog("Consigues caja de 15 balas.");
+  }
+  if (loot.ammo && loot.ammo > 0) {
+    inv = addAmmo(inv, loot.ammo);
+    gameLog(`Consigues munición: +${loot.ammo}`);
+  }
+  return normalizeAmmo(inv);
+}
+
+export default applyAmmoLoot;

--- a/src/systems/combat/getAvailableWeapons.ts
+++ b/src/systems/combat/getAvailableWeapons.ts
@@ -3,7 +3,9 @@
 
 export type WeaponOpt = { id: string; label: string; usable: boolean; reason?: string };
 
-type Player = { inventory?: any[]; ammo?: number };
+import { getAmmoFor } from "../weapons";
+
+type Player = { inventory?: any[]; weaponState?: Record<string, { ammoInMag: number }> };
 
 /** Normaliza a minúsculas, sin tildes y con espacios colapsados */
 function norm(s?: string) {
@@ -41,21 +43,23 @@ export function getAvailableWeapons(player: Player): WeaponOpt[] {
     list.push({ id: "knife", label: "Navaja (1–6)", usable: true });
   }
 
-  const ammo = player.ammo ?? 0;
-
   if (hasAny(player, ALIAS.pistol)) {
+    const ammo = getAmmoFor(player, "pistol");
+    const cap = 15;
     list.push({
       id: "pistol",
-      label: `Pistola (2–8) — Munición: ${ammo}${ammo > 0 ? "" : " (Sin munición)"}`,
+      label: `Pistola (2–8) — Munición: ${ammo}/${cap}${ammo > 0 ? "" : " (Sin munición)"}`,
       usable: true,
       reason: ammo > 0 ? undefined : "Sin munición",
     });
   }
 
   if (hasAny(player, ALIAS.rifle)) {
+    const ammo = getAmmoFor(player, "rifle");
+    const cap = 10;
     list.push({
       id: "rifle",
-      label: `Rifle (4–12) — Munición: ${ammo}${ammo > 0 ? "" : " (Sin munición)"}`,
+      label: `Rifle (4–12) — Munición: ${ammo}/${cap}${ammo > 0 ? "" : " (Sin munición)"}`,
       usable: true,
       reason: ammo > 0 ? undefined : "Sin munición",
     });
@@ -63,18 +67,22 @@ export function getAvailableWeapons(player: Player): WeaponOpt[] {
 
   // Opcionales si tu UI los usa:
   if (hasAny(player, ALIAS.shotgun)) {
+    const ammo = getAmmoFor(player, "shotgun");
+    const cap = 6;
     list.push({
       id: "shotgun",
-      label: `Escopeta (2d4+3) — Munición: ${ammo}${ammo > 0 ? "" : " (Sin munición)"}`,
+      label: `Escopeta (2d4+3) — Munición: ${ammo}/${cap}${ammo > 0 ? "" : " (Sin munición)"}`,
       usable: true,
       reason: ammo > 0 ? undefined : "Sin munición",
     });
   }
 
   if (hasAny(player, ALIAS.smg)) {
+    const ammo = getAmmoFor(player, "smg");
+    const cap = 30;
     list.push({
       id: "smg",
-      label: `SMG (1d6+3) — Munición: ${ammo}${ammo > 0 ? "" : " (Sin munición)"}`,
+      label: `SMG (1d6+3) — Munición: ${ammo}/${cap}${ammo > 0 ? "" : " (Sin munición)"}`,
       usable: true,
       reason: ammo > 0 ? undefined : "Sin munición",
     });

--- a/src/systems/weapons.ts
+++ b/src/systems/weapons.ts
@@ -1,4 +1,5 @@
 import { findWeaponById } from "../data/weapons";
+import { takeAmmo, InventoryItem } from "./ammo";
 
 // Pseudo-arma por defecto (puños), por si no hay selección válida.
 export const FISTS_WEAPON = {
@@ -37,7 +38,11 @@ export function getSelectedWeapon(player: any) {
  * Si no existe estructura, devuelve 0.
  */
 export function getAmmoFor(player: any, weaponId: string): number {
-  return Math.max(0, Number(player?.ammoByWeapon?.[weaponId] ?? 0));
+  const state = player?.weaponState?.[weaponId];
+  if (state && typeof state.ammoInMag === "number") return Math.max(0, state.ammoInMag);
+  // compatibilidad legacy
+  const legacy = player?.ammoByWeapon?.[weaponId] ?? player?.ammo;
+  return Math.max(0, Number(legacy ?? 0));
 }
 
 /**
@@ -45,5 +50,50 @@ export function getAmmoFor(player: any, weaponId: string): number {
  */
 export function isRangedWeapon(w: any): boolean {
   return w?.type === "ranged" || w?.range === "ranged";
+}
+
+/** Asegura que exista el estado de un arma en el jugador */
+export function ensureWeaponState(player: any, weaponId: string) {
+  const table = { ...(player?.weaponState ?? {}) };
+  const cur = table[weaponId] ?? { ammoInMag: 0 };
+  table[weaponId] = cur;
+  return { table, state: cur };
+}
+
+/** Busca un arma en el catálogo */
+export function lookupWeapon(id: string) {
+  return findWeaponById(id);
+}
+
+/**
+ * Recarga un arma consumiendo munición del inventario.
+ */
+export function reloadWeapon(p: any, weaponId: string): { updated: any; log: string[] } {
+  const w = lookupWeapon(weaponId);
+  if (!w || w.type !== "ranged" || !w.magCapacity)
+    return { updated: p, log: ["Esta arma no usa munición."] };
+
+  const { table, state } = ensureWeaponState(p, weaponId);
+  const missing = Math.max(0, w.magCapacity - state.ammoInMag);
+  if (missing === 0) return { updated: p, log: ["El cargador ya está completo."] };
+
+  const { taken, newInv, from } = takeAmmo(p.inventory ?? [], missing);
+  const newAmmo = state.ammoInMag + taken;
+  const newPlayer = {
+    ...p,
+    inventory: newInv as InventoryItem[],
+    weaponState: { ...table, [weaponId]: { ammoInMag: newAmmo } },
+  };
+
+  if (taken === 0) {
+    return { updated: newPlayer, log: ["Intentó recargar, pero no tenía munición compatible."] };
+  }
+
+  const tag = `[${w.name}: ${newAmmo}/${w.magCapacity}]`;
+  if (from === "loose")
+    return { updated: newPlayer, log: [`Recarga ${taken} bala(s) suelta(s). ${tag}`] };
+  if (from === "box")
+    return { updated: newPlayer, log: [`Recarga ${taken} bala(s) desde caja. ${tag}`] };
+  return { updated: newPlayer, log: [`Recarga ${taken} bala(s) (mixto). ${tag}`] };
 }
 


### PR DESCRIPTION
## Summary
- support stacking loose bullets and box conversion in inventory
- track ammo per weapon with magazine capacities and reload logic
- add combat UI reload button and handle firing with empty magazines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c18f5765348325a895a38b79549717