### PR TITLE
Refactor ranged weapons and battle summary logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "tsc src/engine/turns.ts src/systems/combat.ts --module node16 --target ES2020 --moduleResolution node16 --skipLibCheck --outDir build && node --test tests/turns.test.mjs",
+    "test": "tsc src/engine/turns.ts src/systems/combat.ts src/types/combat.ts src/logic/combatUtils.ts src/ui/BattleSummaryModal.tsx --module node16 --target ES2020 --moduleResolution node16 --jsx react --skipLibCheck --outDir build && node --test tests/turns.test.mjs tests/combatUtils.test.mjs tests/battleSummaryModal.test.mjs",
     "test:game": "tsc src/game/items/weapons.ts src/engine/combat.ts src/engine/turn-manager.ts src/systems/weapons.ts src/systems/combat/getAvailableWeapons.ts src/ui/log.ts --module node16 --target ES2020 --moduleResolution node16 --skipLibCheck --outDir build && node --test tests/game.test.mjs"
   },
   "dependencies": {

--- a/src/boot/loadGame.ts
+++ b/src/boot/loadGame.ts
@@ -1,0 +1,6 @@
+export function normalizeSave(save: any) {
+  if (save?.combat?.status === 'finished' && !(save.combat?.rounds?.length)) {
+    save.combat = { status: 'idle', rounds: [], log: [], result: null };
+  }
+  return save;
+}

--- a/src/logic/attack.ts
+++ b/src/logic/attack.ts
@@ -1,0 +1,18 @@
+import { Actor, Weapon } from '../types/combat.js';
+import { ensureLoaded, consumeShot } from './combatUtils.js';
+
+export function performAttack(actor: Actor, target: Actor, weapon: Weapon) {
+  if (weapon.type === 'ranged') {
+    if ((weapon.magAmmo ?? 0) <= 0) {
+      ensureLoaded(actor, weapon);
+    }
+    if ((weapon.magAmmo ?? 0) <= 0) {
+      return { ok: false, reason: 'Sin munición' } as const;
+    }
+    consumeShot(actor, weapon);
+    // resolver hit/daño etc
+  } else {
+    // melee logic
+  }
+  return { ok: true } as const;
+}

--- a/src/logic/combatState.ts
+++ b/src/logic/combatState.ts
@@ -1,0 +1,3 @@
+export function resetCombat(state: any) {
+  state.combat = { status: 'idle', rounds: [], log: [], result: null };
+}

--- a/src/logic/combatUtils.ts
+++ b/src/logic/combatUtils.ts
@@ -1,0 +1,29 @@
+import { Actor, RangedWeapon, Weapon, DiceSpec } from '../types/combat.js';
+
+export function damageRange(d: DiceSpec) {
+  const times = d.times ?? 1;
+  const faces = d.faces ?? 6;
+  const mod = d.mod ?? 0;
+  return {
+    min: times * 1 + mod,
+    max: times * faces + mod,
+  };
+}
+
+export function ensureLoaded(actor: Actor, w: Weapon) {
+  if (w.type !== 'ranged') return;
+  const cost = w.ammoCost ?? 1;
+  const mag = w.magAmmo ?? 0;
+  const need = Math.max(0, (w.magCapacity ?? 0) - mag);
+  const pool = actor.inventory.ammo[w.ammoType] ?? 0;
+  const take = Math.min(need, pool);
+  if (take > 0) {
+    w.magAmmo = mag + take;
+    actor.inventory.ammo[w.ammoType] = pool - take;
+  }
+}
+
+export function consumeShot(actor: Actor, w: RangedWeapon) {
+  const cost = w.ammoCost ?? 1;
+  w.magAmmo = Math.max(0, (w.magAmmo ?? 0) - cost);
+}

--- a/src/logic/equip.ts
+++ b/src/logic/equip.ts
@@ -1,0 +1,7 @@
+import { Actor, Weapon } from '../types/combat.js';
+import { ensureLoaded } from './combatUtils.js';
+
+export function equipWeapon(actor: Actor, w: Weapon) {
+  actor.equipped = w;
+  ensureLoaded(actor, w);
+}

--- a/src/logic/turns.ts
+++ b/src/logic/turns.ts
@@ -1,0 +1,7 @@
+export function advanceTurn(state: any) {
+  const actors = state.actors.filter((a: any) => a.alive && a.hp > 0 && a.status !== 'down');
+  if (actors.length === 0) return; // derrota
+  const idx = Math.max(0, actors.findIndex((a: any) => a.id === state.activeId));
+  const next = actors[(idx + 1) % actors.length];
+  state.activeId = next.id;
+}

--- a/src/types/combat.ts
+++ b/src/types/combat.ts
@@ -1,0 +1,36 @@
+export type DiceSpec = { times: number; faces: number; mod?: number };
+
+export type RangedWeapon = {
+  id: string;
+  name: string;
+  type: 'ranged';
+  damage: DiceSpec;
+  hitBonus?: number;
+  ammoType: '9mm' | 'rifle' | 'shell' | string;
+  ammoCost?: number;
+  magCapacity: number;
+  magAmmo?: number;
+};
+
+export type MeleeWeapon = {
+  id: string;
+  name: string;
+  type: 'melee';
+  damage: DiceSpec;
+  hitBonus?: number;
+};
+
+export type Weapon = RangedWeapon | MeleeWeapon;
+
+export type Actor = {
+  id: string;
+  name: string;
+  hp: number;
+  alive: boolean;
+  status?: 'ok' | 'infected' | 'down';
+  inventory: {
+    ammo: Record<string, number>;
+    items: string[];
+  };
+  equipped?: Weapon;
+};

--- a/src/ui/BattleSummaryModal.tsx
+++ b/src/ui/BattleSummaryModal.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export function shouldShow(state: any) {
+  return state?.combat?.status === 'finished' &&
+    (state?.combat?.rounds?.length ?? 0) > 0 &&
+    !!state?.combat?.result;
+}
+
+export default function BattleSummaryModal({ state, children }: { state: any; children?: React.ReactNode }) {
+  return shouldShow(state) ? <div>{children}</div> : null;
+}

--- a/src/ui/WeaponSelect.tsx
+++ b/src/ui/WeaponSelect.tsx
@@ -1,0 +1,13 @@
+import { Actor, Weapon } from '../types/combat.js';
+import { damageRange } from '../logic/combatUtils.js';
+
+export function weaponLabel(actor: Actor, w: Weapon) {
+  const { min, max } = damageRange(w.damage);
+  if (w.type === 'ranged') {
+    const pool = actor.inventory.ammo[w.ammoType] ?? 0;
+    const mag = w.magAmmo ?? 0;
+    const cap = w.magCapacity ?? 0;
+    return `${w.name} (${min}–${max}) — ${mag}/${cap} • Reserva: ${pool}${mag <= 0 && pool <= 0 ? ' (Sin munición)' : ''}`;
+  }
+  return `${w.name} (${min}–${max})`;
+}

--- a/tests/battleSummaryModal.test.mjs
+++ b/tests/battleSummaryModal.test.mjs
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldShow } from '../build/ui/BattleSummaryModal.js';
+
+test('shouldShow false when not finished', () => {
+  const state = { combat: { status: 'idle', rounds: [], result: null } };
+  assert.equal(shouldShow(state), false);
+});
+
+test('shouldShow true when finished with rounds and result', () => {
+  const state = { combat: { status: 'finished', rounds: [1], result: { winner: 'a' } } };
+  assert.equal(shouldShow(state), true);
+});
+

--- a/tests/combatUtils.test.mjs
+++ b/tests/combatUtils.test.mjs
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { damageRange, ensureLoaded, consumeShot } from '../build/logic/combatUtils.js';
+
+const sampleActor = () => ({
+  id: 'a',
+  name: 'Actor',
+  hp: 10,
+  alive: true,
+  inventory: { ammo: { '9mm': 10 }, items: [] }
+});
+
+const sampleWeapon = () => ({
+  id: 'p',
+  name: 'Pistol',
+  type: 'ranged',
+  damage: { times:1, faces:6, mod:4 },
+  ammoType: '9mm',
+  magCapacity: 15,
+  magAmmo: 0,
+});
+
+test('damageRange computes min and max', () => {
+  const { min, max } = damageRange({ times:1, faces:6, mod:4 });
+  assert.equal(min, 5);
+  assert.equal(max, 10);
+});
+
+test('ensureLoaded moves ammo from pool to magazine', () => {
+  const actor = sampleActor();
+  const weapon = sampleWeapon();
+  ensureLoaded(actor, weapon);
+  assert.equal(weapon.magAmmo, 10);
+  assert.equal(actor.inventory.ammo['9mm'], 0);
+});
+
+test('consumeShot reduces magazine only', () => {
+  const actor = sampleActor();
+  const weapon = sampleWeapon();
+  weapon.magAmmo = 3;
+  consumeShot(actor, weapon);
+  assert.equal(weapon.magAmmo, 2);
+  assert.equal(actor.inventory.ammo['9mm'], 10);
+});


### PR DESCRIPTION
## Summary
- add unified combat type models for weapons and actors
- implement ammo utilities with auto-loading magazines
- gate battle summary modal to only show after real combat

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a83c395c8325be2abd443bd3c9d3