### PR TITLE
Refactor weapon reload to use shared ammo helpers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import {
   spendAmmo,
   totalAmmoInInventory,
 } from "./systems/ammo";
+import { consumeAmmoFromPlayer } from "./helpers";
 import WeaponPicker from "./components/WeaponPicker";
 import CombatEndSummary from "./components/overlays/CombatEndSummary";
 import InfectionFatalModal from "./components/overlays/InfectionFatalModal";
@@ -383,138 +384,6 @@ export default function App(){
   // Normalizador
   function norm(s?: string){ return String(s||"").normalize("NFD").replace(/\p{Diacritic}/gu,"").toLowerCase(); }
 
-  // ¿Es caja de munición?
-  function isAmmoBoxItem(it:any): boolean {
-    if (!it) return false;
-    if (typeof it === "object" && (it.type === "ammo" || it.kind === "ammoBox")) return true;
-    const name = String(it?.name ?? it ?? "").toLowerCase();
-    return /caja\s+de\s+munici(o|ó)n/.test(name);
-  }
-
-  // balas en caja (default 15)
-  function getBoxBullets(it:any): number {
-    if (!isAmmoBoxItem(it)) return 0;
-    if (typeof it === "object") {
-      const n = Number(it.bullets ?? it.count ?? it.qty ?? it.amount ?? 15);
-      return Number.isFinite(n) && n > 0 ? Math.floor(n) : 15;
-    }
-    return 15;
-  }
-
-  // balas sueltas (string "Munición (N)" o objeto {name:"Munición", count:N})
-  function getLooseAmmoCount(it:any): number {
-    if (!it) return 0;
-    if (typeof it === "object") {
-      const nm = String(it.name ?? it.title ?? "").toLowerCase();
-      if (/munici(o|ó)n/.test(nm) && !isAmmoBoxItem(it)) {
-        const n = Number(it.count ?? it.qty ?? it.amount ?? 0);
-        return Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 0;
-      }
-      return 0;
-    }
-    const s = String(it).toLowerCase();
-    const m = s.match(/munici(?:o|ó)n\s*\((\d+)\)/);
-    return m ? Math.max(0, parseInt(m[1],10)) : 0;
-  }
-
-  // total disponible (suelto + cajas) en inventario + mochila
-  function getTotalAmmoAvailable(player:any){
-    const lists = [
-      Array.isArray(player?.inventory) ? player.inventory : [],
-      Array.isArray(player?.backpack)  ? player.backpack  : [],
-    ];
-    let loose = 0, boxesBullets = 0, boxesCount = 0;
-    for (const list of lists){
-      for (const it of list){
-        const boxB = isAmmoBoxItem(it) ? getBoxBullets(it) : 0;
-        if (boxB > 0){ boxesBullets += boxB; boxesCount += 1; continue; }
-        const looseN = getLooseAmmoCount(it);
-        loose += looseN;
-      }
-    }
-    return { loose, boxesBullets, boxesCount, total: loose + boxesBullets };
-  }
-
-  // consume N balas: primero sueltas, luego cajas (parcialmente)
-  function consumeAmmoFromPlayer(player:any, requested:number){
-    let need = Math.max(0, Math.floor(requested));
-    if (need <= 0) return { player, taken: 0 };
-
-    function consumeFromList(list:any[]){
-      const out:any[] = [];
-      let taken = 0;
-      for (const it of list){
-        if (taken >= need){ out.push(it); continue; }
-
-        const loose = getLooseAmmoCount(it);
-        if (loose > 0){
-          const use = Math.min(loose, need - taken);
-          const remain = loose - use;
-          taken += use;
-          if (remain > 0){
-            if (typeof it === "string") out.push(`Munición (${remain})`);
-            else out.push({ ...(it||{}), name: "Munición", count: remain });
-          }
-          continue;
-        }
-        if (isAmmoBoxItem(it)){
-          const box = getBoxBullets(it);
-          const use = Math.min(box, need - taken);
-          const remain = box - use;
-          taken += use;
-          if (remain > 0) out.push({ name:"Caja de munición", bullets: remain, kind:"ammoBox" });
-          continue;
-        }
-        out.push(it);
-      }
-      return { out, taken };
-    }
-
-    const inv = Array.isArray(player?.inventory) ? player.inventory : [];
-    const bp  = Array.isArray(player?.backpack)  ? player.backpack  : [];
-
-    const a = consumeFromList(inv);
-    const b = (a.taken >= need) ? { out: bp, taken: 0 } : consumeFromList(bp);
-
-    const totalTaken = a.taken + b.taken;
-    return { player: { ...player, inventory: a.out, backpack: b.out }, taken: totalTaken };
-  }
-
-  // armas recargables (catálogo + strings)
-  function listReloadableWeapons(player:any): {id:string; name:string}[]{
-    const list: {id:string; name:string}[] = [];
-    const add = (id:string, name:string) => { if(!list.find(w=>w.id===id)) list.push({id,name}); };
-
-    const selId = (player as any)?.currentWeaponId ?? (player as any)?.selectedWeaponId;
-    const byId = selId ? WEAPONS.find(w => w.id === selId) : null;
-    if (byId && byId.type === "ranged") add(byId.id, byId.name);
-
-    const all = [
-      ...(Array.isArray(player?.inventory) ? player.inventory : []),
-      ...(Array.isArray(player?.backpack)  ? player.backpack  : []),
-    ];
-    for (const it of all){
-      if (typeof it === "string"){
-        const s = norm(it);
-        const match = WEAPONS.find(w => w.type === "ranged" && (norm(w.name)===s || w.id===s));
-        if (match) add(match.id, match.name);
-        continue;
-      }
-      if (it && typeof it === "object"){
-        if (it.type === "ranged" && typeof it.id === "string"){
-          const w = WEAPONS.find(w => w.id === it.id) ?? { id: it.id, name: (it as any).name ?? it.id, type:"ranged" } as any;
-          add(w.id, w.name);
-        } else if (typeof (it as any).name === "string"){
-          const nm = norm((it as any).name);
-          const match2 = WEAPONS.find(w => w.type === "ranged" && norm(w.name)===nm);
-          if (match2) add(match2.id, match2.name);
-        }
-      }
-    }
-    return list;
-  }
-
-
   // confirma recarga desde el modal
   function confirmReload(weaponId: string, bullets: number) {
     const pid = activePlayerId;
@@ -522,72 +391,6 @@ export default function App(){
 
     setPlayers(prev => prev.map(p => {
       if (p.id !== pid) return p;
-
-      // helpers locales (con los mismos que ya usa tu función: norm, isBox, boxBullets, looseCount, consume)
-      const norm = (s?: string) => String(s || "").normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
-      const isBox = (it: any) => {
-        if (!it) return false;
-        if (typeof it === "object" && (it.type === "ammo" || it.kind === "ammoBox")) return true;
-        const nm = norm((it?.name ?? it) as any);
-        return /caja\s+de\s+municion/.test(nm);
-      };
-      const boxBullets = (it: any) => {
-        if (!it) return 0;
-        if (typeof it === "object") {
-          const n = Number(it.bullets ?? it.count ?? it.qty ?? it.amount ?? 15);
-          return Number.isFinite(n) && n > 0 ? Math.floor(n) : 15;
-        }
-        return 15;
-      };
-      const looseCount = (it: any) => {
-        if (!it) return 0;
-        if (typeof it === "object") {
-          const nm = norm(String(it.name ?? it.title ?? ""));
-          if (/municion/.test(nm) && !isBox(it)) {
-            const n = Number(it.count ?? it.qty ?? it.amount ?? 0);
-            return Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 0;
-          }
-          return 0;
-        }
-        const s = norm(String(it));
-        const m = s.match(/municion\s*\((\d+)\)/);
-        return m ? Math.max(0, parseInt(m[1], 10)) : 0;
-      };
-
-      function consume(list: any[], need: number) {
-        const out: any[] = [];
-        let taken = 0;
-        for (const it of list) {
-          if (taken >= need) { out.push(it); continue; }
-
-          const l = looseCount(it);
-          if (l > 0) {
-            const use = Math.min(l, need - taken);
-            const left = l - use;
-            if (typeof it === "object") {
-              if (left > 0) out.push({ ...it, count: left, qty: left, amount: left });
-            } else {
-              if (left > 0) out.push(`Munición (${left})`);
-            }
-            taken += use;
-            continue;
-          }
-
-          if (isBox(it)) {
-            const b = boxBullets(it);
-            if (b > 0 && taken < need) {
-              const use = Math.min(b, need - taken);
-              const left = b - use;
-              if (left > 0) out.push({ ...(typeof it === "object" ? it : { name: String(it) }), bullets: left, count: left, qty: left, amount: left });
-              taken += use;
-              continue;
-            }
-          }
-
-          out.push(it);
-        }
-        return { out, taken };
-      }
 
       // --- lógica de recarga sincronizada con el cargador ---
       const weapon = WEAPONS.find(w => w.id === weaponId);
@@ -599,16 +402,11 @@ export default function App(){
       const need = Math.min(desired, freeSpace);
       if (need <= 0) return p;
 
-      const inv = Array.isArray((p as any).inventory) ? (p as any).inventory : [];
-      const bp = Array.isArray((p as any).backpack) ? (p as any).backpack : [];
-
-      const a = consume(inv, need);
-      const b = a.taken >= need ? { out: bp, taken: 0 } : consume(bp, need - a.taken);
-      const taken = a.taken + b.taken;
+      const { player: afterConsume, taken } = consumeAmmoFromPlayer(p, need);
       if (taken <= 0) return p;
 
       const nextLoaded = Math.min(magSize, curLoaded + taken);
-      const afterLoad = setLoadedAmmo({ ...p, inventory: a.out, backpack: b.out }, weaponId, nextLoaded);
+      const afterLoad = setLoadedAmmo(afterConsume, weaponId, nextLoaded);
 
       // Mantener compatibilidad con rutas legacy que consultan ammoByWeapon
       const table = { ...(afterLoad.ammoByWeapon ?? {}) };

--- a/src/components/overlays/AmmoReloadModal.tsx
+++ b/src/components/overlays/AmmoReloadModal.tsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
+import { WEAPONS } from "../../data/weapons";
+import { getLoadedAmmo } from "../../systems/ammo";
+import { getTotalAmmoAvailable, listReloadableWeapons } from "../../helpers";
 
 type Weapon = { id:string; name:string };
 
@@ -8,87 +11,6 @@ type Props = {
   onClose: () => void;
   onConfirm: (weaponId:string, bullets:number) => void;
 };
-
-// Helpers (idénticos a App) mínimos que necesitamos
-function norm(s?: string){ return String(s||"").normalize("NFD").replace(/\p{Diacritic}/gu,"").toLowerCase(); }
-function isAmmoBoxItem(it:any): boolean {
-  if (!it) return false;
-  if (typeof it === "object" && (it.type === "ammo" || it.kind === "ammoBox")) return true;
-  const name = String(it?.name ?? it ?? "").toLowerCase();
-  return /caja\s+de\s+munici(o|ó)n/.test(name);
-}
-function getBoxBullets(it:any): number {
-  if (!isAmmoBoxItem(it)) return 0;
-  if (typeof it === "object") {
-    const n = Number(it.bullets ?? it.count ?? it.qty ?? it.amount ?? 15);
-    return Number.isFinite(n) && n > 0 ? Math.floor(n) : 15;
-  }
-  return 15;
-}
-function getLooseAmmoCount(it:any): number {
-  if (!it) return 0;
-  if (typeof it === "object") {
-    const nm = String(it.name ?? it.title ?? "").toLowerCase();
-    if (/munici(o|ó)n/.test(nm) && !isAmmoBoxItem(it)) {
-      const n = Number(it.count ?? it.qty ?? it.amount ?? 0);
-      return Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 0;
-    }
-    return 0;
-  }
-  const s = String(it).toLowerCase();
-  const m = s.match(/munici(?:o|ó)n\s*\((\d+)\)/);
-  return m ? Math.max(0, parseInt(m[1],10)) : 0;
-}
-function getTotalAmmoAvailable(player:any){
-  const lists = [
-    Array.isArray(player?.inventory) ? player.inventory : [],
-    Array.isArray(player?.backpack)  ? player.backpack  : [],
-  ];
-  let loose = 0, boxesBullets = 0;
-  for (const list of lists){
-    for (const it of list){
-      const boxB = isAmmoBoxItem(it) ? getBoxBullets(it) : 0;
-      if (boxB > 0){ boxesBullets += boxB; continue; }
-      loose += getLooseAmmoCount(it);
-    }
-  }
-  return { total: loose + boxesBullets };
-}
-
-import { WEAPONS } from "../../data/weapons";
-import { getLoadedAmmo } from "../../systems/ammo";
-function listReloadableWeapons(player:any): Weapon[] {
-  const list: Weapon[] = [];
-  const add = (id:string, name:string) => { if(!list.find(w=>w.id===id)) list.push({id,name}); };
-
-  const selId = (player as any)?.currentWeaponId ?? (player as any)?.selectedWeaponId;
-  const byId = selId ? WEAPONS.find(w => w.id === selId) : null;
-  if (byId && byId.type === "ranged") add(byId.id, byId.name);
-
-  const all = [
-    ...(Array.isArray(player?.inventory) ? player.inventory : []),
-    ...(Array.isArray(player?.backpack)  ? player.backpack  : []),
-  ];
-  for (const it of all){
-    if (typeof it === "string"){
-      const s = norm(it);
-      const match = WEAPONS.find(w => w.type === "ranged" && (norm(w.name)===s || w.id===s));
-      if (match) add(match.id, match.name);
-      continue;
-    }
-    if (it && typeof it === "object"){
-      if (it.type === "ranged" && typeof it.id === "string"){
-        const w = WEAPONS.find(w => w.id === it.id) ?? { id: it.id, name: (it as any).name ?? it.id };
-        add(w.id, w.name);
-      } else if (typeof (it as any).name === "string"){
-        const nm = norm((it as any).name);
-        const match2 = WEAPONS.find(w => w.type === "ranged" && norm(w.name)===nm);
-        if (match2) add(match2.id, match2.name);
-      }
-    }
-  }
-  return list;
-}
 
 export default function AmmoReloadModal({ isOpen, player, onClose, onConfirm }: Props){
   if(!isOpen || !player) return null;


### PR DESCRIPTION
## Summary
- Deduplicate ammo utilities by importing shared helpers in `AmmoReloadModal`
- Simplify `confirmReload` in `App.tsx` to consume ammo via `consumeAmmoFromPlayer` and sync magazine with `setLoadedAmmo`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c32cfd65088325aaf9456942abf2ae