### PR TITLE
feat(ammo): stock global y recarga desde mochila

### DIFF
--- a/src/components/ReloadModal.tsx
+++ b/src/components/ReloadModal.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from "react";
+import { getSelectedWeapon, isRangedWeapon } from "../systems/weapons";
+import { getLoadedAmmo, listAmmoBoxes, listLoose, loadFromBackpackExact } from "../systems/ammo";
+import { ensureBreathPlomoStyle } from "./util/breathPlomo";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  state: any;
+  setState: (s:any)=>void;
+};
+
+export default function ReloadModal({isOpen,onClose,state,setState}:Props){
+  ensureBreathPlomoStyle();
+  const pIdx = state?.turn?.activeIndex ?? 0;
+  const player = state?.players?.[pIdx];
+  if(!isOpen || !player) return null;
+  const weapon = getSelectedWeapon(player);
+  if(!isRangedWeapon(weapon)) return null;
+  const loaded = getLoadedAmmo(player, weapon.id);
+  const magSize = Number(weapon?.magSize ?? 0);
+  const free = Math.max(0, magSize - loaded);
+  const loose = listLoose(player.inventory).reduce((a,r)=>a+r.bullets,0);
+  const boxes = listAmmoBoxes(player.inventory).reduce((a,r)=>a+r.bullets,0);
+  const available = loose + boxes;
+  const maxLoad = Math.min(free, available);
+  const [count,setCount] = useState(maxLoad);
+  useEffect(()=>{ setCount(maxLoad); }, [maxLoad, isOpen]);
+  const confirm = ()=>{
+    const next = loadFromBackpackExact(state, count);
+    setState(next);
+    onClose();
+  };
+  const disabled = count<=0;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-sm p-6 rounded-2xl bg-neutral-900 border border-neutral-800 text-neutral-100" role="dialog" aria-modal>
+        <button className="absolute top-2 right-3" onClick={onClose}>✖</button>
+        <h3 className="text-lg font-bold mb-2">Recargar arma</h3>
+        <p className="text-sm text-neutral-400 mb-4">Disponible en mochila: {available} • Espacio libre: {free}</p>
+        <div className="flex items-center justify-between">
+          <span className="text-sm">Balas a cargar</span>
+          <div className="flex items-center gap-2">
+            <button className="px-2 py-1 bg-neutral-800 rounded" onClick={()=>setCount(c=>Math.max(0,c-1))}>-</button>
+            <span>{count}</span>
+            <button className="px-2 py-1 bg-neutral-800 rounded" onClick={()=>setCount(c=>Math.min(maxLoad,c+1))}>+</button>
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end gap-2">
+          <button className="px-4 py-2 bg-neutral-800 rounded" onClick={onClose}>Cancelar</button>
+          <button className={`px-4 py-2 rounded ${disabled? 'btn-disabled':'breath-plomo'}`} disabled={disabled} onClick={confirm}>Cargar</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/StockAmmoModal.tsx
+++ b/src/components/StockAmmoModal.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import { takeAmmoFromCamp } from "../systems/ammo";
+import { ensureBreathPlomoStyle } from "./util/breathPlomo";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  state: any;
+  setState: (s: any) => void;
+};
+
+export default function StockAmmoModal({ isOpen, onClose, state, setState }: Props){
+  ensureBreathPlomoStyle();
+  const stock = Math.max(0, Number(state?.camp?.resources?.ammo ?? 0));
+  const [loose, setLoose] = useState(0);
+  const [boxes, setBoxes] = useState(0);
+
+  useEffect(()=>{ if(isOpen){ setLoose(0); setBoxes(0); } }, [isOpen]);
+  if(!isOpen) return null;
+
+  const total = loose + boxes*15;
+  const maxLoose = Math.max(0, stock - boxes*15);
+  const maxBoxes = Math.floor((stock - loose)/15);
+
+  const dec = (v:number,set:(n:number)=>void)=> set(Math.max(0,v-1));
+  const incLoose = ()=> setLoose(l=> Math.min(maxLoose, l+1));
+  const incBoxes = ()=> setBoxes(b=> Math.min(maxBoxes, b+1));
+
+  const disabled = total<=0 || total>stock;
+  const confirm = ()=>{
+    const next = takeAmmoFromCamp(state, { loose, boxes });
+    setState(next);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/60" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-sm p-6 rounded-2xl bg-neutral-900 border border-neutral-800 text-neutral-100" role="dialog" aria-modal>
+        <button className="absolute top-2 right-3" onClick={onClose}>✖</button>
+        <h3 className="text-lg font-bold mb-2">Cajón de Munición</h3>
+        <p className="text-sm text-neutral-400 mb-4">Stock: {stock} balas</p>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Balas sueltas</span>
+            <div className="flex items-center gap-2">
+              <button className="px-2 py-1 bg-neutral-800 rounded" onClick={()=>dec(loose,setLoose)}>-</button>
+              <span>{loose}</span>
+              <button className="px-2 py-1 bg-neutral-800 rounded" onClick={incLoose}>+</button>
+            </div>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Cajas (x15)</span>
+            <div className="flex items-center gap-2">
+              <button className="px-2 py-1 bg-neutral-800 rounded" onClick={()=>dec(boxes,setBoxes)}>-</button>
+              <span>{boxes}</span>
+              <button className="px-2 py-1 bg-neutral-800 rounded" onClick={incBoxes}>+</button>
+            </div>
+          </div>
+          <div className="text-sm text-neutral-400">Retirarás {total} balas</div>
+        </div>
+        <div className="mt-4 flex justify-end gap-2">
+          <button className="px-4 py-2 bg-neutral-800 rounded" onClick={onClose}>Cancelar</button>
+          <button className={`px-4 py-2 rounded ${disabled? 'btn-disabled':'breath-plomo'}`} disabled={disabled} onClick={confirm}>Retirar del stock</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/util/breathPlomo.ts
+++ b/src/components/util/breathPlomo.ts
@@ -1,0 +1,22 @@
+export function ensureBreathPlomoStyle(){
+  const id = "breath-plomo-style";
+  if (typeof document === "undefined") return;
+  if (document.getElementById(id)) return;
+  const style = document.createElement("style");
+  style.id = id;
+  style.textContent = `
+      @keyframes breath-plomo {
+        0%   { transform: scale(1);    box-shadow: 0 0 0 rgba(150,150,150,0.0); }
+        50%  { transform: scale(1.02); box-shadow: 0 0 18px rgba(150,150,150,0.25); }
+        100% { transform: scale(1);    box-shadow: 0 0 0 rgba(150,150,150,0.0); }
+      }
+      .breath-plomo {
+        animation: breath-plomo 2.4s ease-in-out infinite;
+        border: 1px solid #3d3d3d;
+      }
+      .btn-disabled {
+        opacity: .45; cursor: not-allowed; filter: grayscale(0.4);
+      }
+    `;
+  document.head.appendChild(style);
+}

--- a/src/systems/ammo.ts
+++ b/src/systems/ammo.ts
@@ -27,6 +27,29 @@ export function ammoCount(item: any): number {
   return isLooseAmmo(item) ? 1 : 0;
 }
 
+export function ensureAmmoNames(item: any){
+  const kind = item?.kind === "box" ? "box" : "loose";
+  const amount = Math.max(0, Math.floor(Number(item?.amount ?? 0)));
+  const name = kind === "box" ? `Caja de munición (${amount})` : `Munición (${amount})`;
+  return { ...item, type: "ammo", kind, amount, qty: amount, count: amount, name };
+}
+
+export function addLoose(inv: any[] | null | undefined, n: number){
+  const arr = Array.isArray(inv) ? [...inv] : [];
+  const amount = Math.max(0, Math.floor(n));
+  if (amount <= 0) return arr;
+  arr.push(ensureAmmoNames({ kind: "loose", amount }));
+  return arr;
+}
+
+export function addBox(inv: any[] | null | undefined, n: number){
+  const arr = Array.isArray(inv) ? [...inv] : [];
+  const amount = Math.max(0, Math.floor(n));
+  if (amount <= 0) return arr;
+  arr.push(ensureAmmoNames({ kind: "box", amount }));
+  return arr;
+}
+
 export function listAmmoBoxes(inv: any[] | undefined | null){
   const arr = Array.isArray(inv) ? inv : [];
   return arr.map((it, i) => ({ i, it, bullets: ammoCount(it) }))
@@ -39,16 +62,7 @@ export function listLoose(inv: any[] | undefined | null){
             .filter(row => isLooseAmmo(row.it) && row.bullets > 0);
 }
 
-export function consumeOneBox(inv: any[] | undefined | null){
-  const arr = Array.isArray(inv) ? [...inv] : [];
-  const boxes = listAmmoBoxes(arr);
-  if (!boxes.length) return { bullets: 0, inv: arr };
-  const { i, bullets } = boxes[0];
-  arr.splice(i, 1);
-  return { bullets, inv: arr };
-}
-
-export function consumeLoose(inv: any[] | undefined | null, need: number){
+export function reduceLoose(inv: any[] | undefined | null, need: number){
   const arr = Array.isArray(inv) ? [...inv] : [];
   let taken = 0;
   for (let idx = 0; idx < arr.length && taken < need; idx++){
@@ -60,12 +74,43 @@ export function consumeLoose(inv: any[] | undefined | null, need: number){
     if (left <= 0){
       arr.splice(idx,1); idx--;
     } else {
-      const base = typeof it === "object" ? it : { name: String(it ?? "Munición") };
-      arr[idx] = { ...base, amount: left, qty: left, count: left };
+      arr[idx] = ensureAmmoNames({ ...(typeof it === "object" ? it : {}), kind: "loose", amount: left });
     }
     taken += take;
   }
   return { taken, inv: arr };
+}
+
+export function reduceBoxes(inv: any[] | undefined | null, need: number){
+  const arr = Array.isArray(inv) ? [...inv] : [];
+  let taken = 0;
+  for (let idx = 0; idx < arr.length && taken < need; idx++){
+    const it = arr[idx];
+    const bullets = isAmmoBox(it) ? ammoCount(it) : 0;
+    if (bullets <= 0) continue;
+    const take = Math.min(need - taken, bullets);
+    const left = bullets - take;
+    if (left <= 0){
+      arr.splice(idx,1); idx--;
+    } else {
+      arr[idx] = ensureAmmoNames({ ...(typeof it === "object" ? it : {}), kind: "box", amount: left });
+    }
+    taken += take;
+  }
+  return { taken, inv: arr };
+}
+
+export function consumeOneBox(inv: any[] | undefined | null){
+  const arr = Array.isArray(inv) ? [...inv] : [];
+  const boxes = listAmmoBoxes(arr);
+  if (!boxes.length) return { bullets: 0, inv: arr };
+  const { i, bullets } = boxes[0];
+  arr.splice(i, 1);
+  return { bullets, inv: arr };
+}
+
+export function consumeLoose(inv: any[] | undefined | null, need: number){
+  return reduceLoose(inv, need);
 }
 
 export function getLoadedAmmo(player: any, weaponId: string): number {
@@ -92,41 +137,75 @@ export function totalAmmoInInventory(inv: any[] | null | undefined): number {
   return boxes + loose;
 }
 
+export function loadFromBackpackExact(state: any, amount: number){
+  const pIdx = state?.turn?.activeIndex ?? 0;
+  const player = state?.players?.[pIdx];
+  if (!player) return state;
+  const w = getSelectedWeapon(player);
+  if (!isRangedWeapon(w)) return state;
+  const mag = Number(w?.magSize ?? 0);
+  const cur = getLoadedAmmo(player, w.id);
+  const free = Math.max(0, mag - cur);
+  const need = Math.min(Math.max(0, Math.floor(amount)), free);
+  if (need <= 0) return state;
+
+  let inventory = Array.isArray(player.inventory) ? [...player.inventory] : [];
+  const loose = reduceLoose(inventory, need);
+  let taken = loose.taken;
+  inventory = loose.inv;
+  if (taken < need){
+    const fromBoxes = reduceBoxes(inventory, need - taken);
+    taken += fromBoxes.taken;
+    inventory = fromBoxes.inv;
+  }
+  if (taken <= 0) return state;
+  const load = Math.min(need, taken);
+  const updated = setLoadedAmmo({ ...player, inventory }, w.id, cur + load);
+  const next = { ...state, players: [...state.players] };
+  next.players[pIdx] = updated;
+  return next;
+}
+
+export function takeAmmoFromCamp(state: any, opts: { loose: number; boxes: number }){
+  const loose = Math.max(0, Math.floor(opts?.loose ?? 0));
+  const boxes = Math.max(0, Math.floor(opts?.boxes ?? 0));
+  const total = loose + boxes * 15;
+  const stock = Math.max(0, Number(state?.camp?.resources?.ammo ?? 0));
+  if (total <= 0 || total > stock) return state;
+  const pIdx = state?.turn?.activeIndex ?? 0;
+  const player = state?.players?.[pIdx];
+  if (!player) return state;
+  let inventory = Array.isArray(player.inventory) ? [...player.inventory] : [];
+  if (loose > 0) inventory = addLoose(inventory, loose);
+  for (let i = 0; i < boxes; i++) inventory = addBox(inventory, 15);
+  const nextPlayers = [...state.players];
+  nextPlayers[pIdx] = { ...player, inventory };
+  return {
+    ...state,
+    camp: { ...(state.camp ?? {}), resources: { ...(state.camp?.resources ?? {}), ammo: stock - total } },
+    players: nextPlayers,
+  };
+}
+
+export function canReloadFromBackpack(player: any): boolean {
+  const w = getSelectedWeapon(player);
+  if (!isRangedWeapon(w)) return false;
+  const hasLoose = listLoose(player?.inventory).length > 0;
+  const hasBoxes = listAmmoBoxes(player?.inventory).length > 0;
+  return hasLoose || hasBoxes;
+}
+
 export function reloadSelectedWeapon(state: any){
   const pIdx = state?.turn?.activeIndex ?? 0;
   const player = state?.players?.[pIdx];
   if (!player) return state;
   const w = getSelectedWeapon(player);
   if (!isRangedWeapon(w)) return state;
-
   const mag = Number(w?.magSize ?? 0);
   const cur = getLoadedAmmo(player, w.id);
   const free = Math.max(0, mag - cur);
   if (free <= 0) return state;
-
-  const fromLoose = consumeLoose(player.inventory, free);
-  let taken = fromLoose.taken;
-  let inventory = fromLoose.inv;
-
-  if (taken < free){
-    const { bullets, inv } = consumeOneBox(inventory);
-    inventory = inv;
-    const use = Math.min(free - taken, bullets);
-    taken += use;
-    const leftover = bullets - use;
-    if (leftover > 0) {
-      inventory = [{ type: 'ammo', kind: 'box', amount: leftover }, ...inventory];
-    }
-  }
-
-  if (taken <= 0) return state;
-
-  const load = Math.min(free, taken);
-  const updated = setLoadedAmmo({ ...player, inventory }, w.id, cur + load);
-
-  const next = { ...state, players: [...state.players] };
-  next.players[pIdx] = updated;
-  return next;
+  return loadFromBackpackExact(state, free);
 }
 
 export const listAmmoboxes = listAmmoBoxes;


### PR DESCRIPTION
## Summary
- add typed ammo helpers with box remainder handling
- add stock and reload modals with breath plomo effect
- integrate camp ammo tile and player reload button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c472bf365c832588ef14eaf5de7551