### PR TITLE
feat: automate battle log and message flow

### DIFF
--- a/src/components/overlays/OverlayRoot.tsx
+++ b/src/components/overlays/OverlayRoot.tsx
@@ -1,6 +1,8 @@
-import { useAdvanceControls } from "../../hooks/useAdvanceControls";
-
-export default function OverlayRoot({ overlayOpen, proceed }: { overlayOpen: boolean; proceed: () => void }) {
-  useAdvanceControls(proceed, { enabled: overlayOpen, mobileOnly: true });
+import { useEffect } from "react";
+export default function OverlayRoot({ overlayOpen, proceed }:{ overlayOpen:boolean; proceed:()=>void }) {
+  useEffect(() => {
+    if (!overlayOpen) return;
+    // no hace nada aquí; el avance lo maneja App con typewriter
+  }, [overlayOpen]);
   return null;
 }


### PR DESCRIPTION
## Summary
- remove input-based advancement and add auto-advance timer for typewriter queue
- log battle events via `gameLog` and auto-scroll log panel

## Testing
- `npm test`
- `npm run test:game` *(fails: File 'src/game/items/weapons.ts' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c854f65c8325a2f8cad57907e097