### PR TITLE
Fix turn advancement with reaction queue and counterattacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "tsc src/logic/combatUtils.ts --module ESNext --target ES2020 --moduleResolution bundler --jsx react --skipLibCheck --outDir build && node --experimental-specifier-resolution=node --test tests/combatUtils.test.mjs",
-    "test:game": "tsc src/game/items/weapons.ts src/engine/combat.ts src/engine/turn-manager.ts src/systems/weapons.ts src/systems/combat/getAvailableWeapons.ts src/ui/log.ts --module ESNext --target ES2020 --moduleResolution bundler --skipLibCheck --outDir build && node --experimental-specifier-resolution=node --test tests/game.test.mjs"
+    "test:game": "tsc src/data/weapons.ts src/engine/combat.ts src/engine/turn-manager.ts src/systems/ammo.ts src/systems/weapons.ts src/systems/combat/getAvailableWeapons.ts src/ui/log.ts --module ESNext --target ES2020 --moduleResolution bundler --skipLibCheck --outDir build && node --experimental-specifier-resolution=node --test tests/game.test.mjs tests/turn-manager.test.mjs"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/src/engine/combat.ts
+++ b/src/engine/combat.ts
@@ -1,5 +1,5 @@
-import { findWeaponById, Weapon } from "../data/weapons";
-import { spendAmmo, getLoadedAmmo } from "../systems/ammo";
+import { findWeaponById, Weapon } from "../data/weapons.js";
+import { spendAmmo, getLoadedAmmo } from "../systems/ammo.js";
 
 export interface Actor {
   id: string;

--- a/src/engine/turn-manager.ts
+++ b/src/engine/turn-manager.ts
@@ -1,5 +1,11 @@
-export interface TurnActor { id: string; hp: number; status?: string };
+export interface TurnActor { id: string; hp: number; status?: string; canCounter?: boolean };
 
+export type Reaction = () => void | Promise<void>;
+
+/**
+ * Avanza el indice al siguiente actor vivo en el orden dado.
+ * Ignora actores con hp <= 0 o status 'dead'/'out'.
+ */
 export function advanceTurn(order: string[], actors: Record<string, TurnActor>, current: number): number {
   let idx = current;
   const len = order.length;
@@ -11,4 +17,59 @@ export function advanceTurn(order: string[], actors: Record<string, TurnActor>, 
     }
   }
   return current;
+}
+
+/** Gestor de turnos con cola de reacciones.
+ * Todas las acciones (y sus reacciones) terminan con un único avance de turno.
+ */
+export class TurnManager {
+  private order: string[];
+  actors: Record<string, TurnActor>;
+  private idx: number;
+  private reactionQueue: Reaction[] = [];
+  private turnLock = false;
+  private listeners: ((actor: TurnActor) => void)[] = [];
+
+  constructor(order: string[], actors: Record<string, TurnActor>, current = 0) {
+    this.order = order;
+    this.actors = actors;
+    this.idx = current;
+  }
+
+  currentActor(): TurnActor {
+    return this.actors[this.order[this.idx]];
+  }
+
+  onTurnChange(fn: (actor: TurnActor) => void) {
+    this.listeners.push(fn);
+  }
+
+  enqueueReaction(r: Reaction) {
+    this.reactionQueue.push(r);
+  }
+
+  private async processReactions() {
+    while (this.reactionQueue.length) {
+      const r = this.reactionQueue.shift()!;
+      try {
+        await r();
+      } catch {
+        // swallow errors to guarantee turn advance
+      }
+    }
+  }
+
+  async execute(action: () => void | Promise<void>) {
+    if (this.turnLock) return;
+    this.turnLock = true;
+    try {
+      await action();
+      await this.processReactions();
+    } finally {
+      this.turnLock = false;
+      this.idx = advanceTurn(this.order, this.actors, this.idx);
+      const actor = this.currentActor();
+      this.listeners.forEach(fn => fn(actor));
+    }
+  }
 }

--- a/src/systems/ammo.ts
+++ b/src/systems/ammo.ts
@@ -1,4 +1,4 @@
-import { getSelectedWeapon, isRangedWeapon } from "./weapons";
+import { getSelectedWeapon, isRangedWeapon } from "./weapons.js";
 
 function norm(s?: string) {
   return String(s || "").normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();

--- a/src/systems/combat/getAvailableWeapons.ts
+++ b/src/systems/combat/getAvailableWeapons.ts
@@ -3,8 +3,8 @@
 
 export type WeaponOpt = { id: string; label: string; usable: boolean; reason?: string };
 
-import { getAmmoFor } from "../weapons";
-import { findWeaponById } from "../../data/weapons";
+import { getAmmoFor } from "../weapons.js";
+import { findWeaponById } from "../../data/weapons.js";
 
 type Player = { inventory?: any[]; ammoByWeapon?: Record<string, number> };
 

--- a/src/systems/weapons.ts
+++ b/src/systems/weapons.ts
@@ -1,4 +1,4 @@
-import { findWeaponById } from "../data/weapons";
+import { findWeaponById } from "../data/weapons.js";
 
 export function getSelectedWeapon(player: any) {
   const id = player?.currentWeaponId ?? player?.selectedWeaponId ?? "fists";

--- a/tests/turn-manager.test.mjs
+++ b/tests/turn-manager.test.mjs
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { TurnManager } from '../build/engine/turn-manager.js';
+import { attack } from '../build/engine/combat.js';
+
+function fixedRng(vals) {
+  let i = 0;
+  return () => vals[i++ % vals.length];
+}
+
+function baseActors() {
+  return {
+    a: { id:'a', name:'A', hp:10, def:10, canCounter:true },
+    b: { id:'b', name:'B', hp:10, def:10, canCounter:true },
+    c: { id:'c', name:'C', hp:10, def:10, canCounter:true },
+  };
+}
+
+async function doAttack(tm, atkId, defId, rng) {
+  const atk = tm.actors[atkId];
+  const def = tm.actors[defId];
+  const res = attack(atk, def, 'fists', rng);
+  tm.actors[atkId] = res.attacker;
+  tm.actors[defId] = res.defender;
+  if (res.defender.hp > 0 && res.defender.canCounter) {
+    tm.actors[defId].canCounter = false;
+    tm.enqueueReaction(() => {
+      const r2 = attack(tm.actors[defId], tm.actors[atkId], 'fists', rng);
+      tm.actors[defId] = r2.attacker;
+      tm.actors[atkId] = r2.defender;
+    });
+  }
+}
+
+test('avanza turno tras contraataque (hit)', async () => {
+  const rng = fixedRng([0.9,0.5, 0.9,0.5]);
+  const actors = baseActors();
+  const tm = new TurnManager(['a','b','c'], actors);
+  await tm.execute(() => doAttack(tm,'a','b',rng));
+  assert.equal(tm.currentActor().id, 'b');
+});
+
+test('avanza turno tras contraataque (miss/bloqueo)', async () => {
+  const rng = fixedRng([0.9,0.5, 0.1]);
+  const actors = baseActors();
+  const tm = new TurnManager(['a','b','c'], actors);
+  await tm.execute(() => doAttack(tm,'a','b',rng));
+  assert.equal(tm.currentActor().id, 'b');
+});
+
+test('no contraataca si el defensor muere', async () => {
+  const rng = fixedRng([0.9,0.9]);
+  const actors = baseActors();
+  actors.b.hp = 3;
+  const tm = new TurnManager(['a','b','c'], actors);
+  await tm.execute(() => doAttack(tm,'a','b',rng));
+  assert.equal(tm.currentActor().id, 'c');
+});


### PR DESCRIPTION
## Summary
- add TurnManager with reaction queue and lock to guarantee single turn advance
- mark counterattack reactions and skip dead defenders
- add tests for turn advance after counterattacks and killing blows

## Testing
- `npm run test:game`


------
https://chatgpt.com/codex/tasks/task_e_68c505d776408325bbcbbe467653ad2f