### PR TITLE
Add modal buttons for camp resources

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,8 @@ import DayEndModal from "./components/overlays/DayEndModal";
 import AmmoWithdrawModal from "./components/overlays/AmmoWithdrawModal";
 import AmmoReloadModal from "./components/overlays/AmmoReloadModal";
 import OverlayRoot from "./components/overlays/OverlayRoot";
+import CampTileButton from "./components/CampTileButton";
+import Modal from "./components/Modal";
 import { registerLogger, gameLog, registerTimeProvider } from "./utils/logger";
 import { DAY_LENGTH_MS, ACTION_TIME_COSTS } from "./config/time";
 import { day1DecisionCards } from "./data/days/day1/decisionCards.day1";
@@ -2019,7 +2021,7 @@ function advanceTurn() {
           setCamp={setCamp}
         />
 
-        <CampPanel resources={resources} setResources={setResources} setShowAmmoModal={setShowAmmoModal} />
+        <CampPanel resources={resources} setResources={setResources} />
 
         <LogPanel log={logs} />
       </main>
@@ -2766,32 +2768,49 @@ function CampRepair({resources, camp, setResources, setCamp}:{resources:Resource
   );
 }
 
-function CampPanel({resources, setResources, setShowAmmoModal}:{resources:Resources; setResources:React.Dispatch<React.SetStateAction<Resources>>; setShowAmmoModal:React.Dispatch<React.SetStateAction<boolean>>}){
+function CampPanel({resources, setResources}:{resources:Resources; setResources:React.Dispatch<React.SetStateAction<Resources>>}){
+  const [openModal, setOpenModal] = useState<null | "food" | "medicine" | "ammo">(null);
   const total = Object.values(resources).reduce((a,b)=>a+b,0);
+  const iconMap: Record<keyof Resources, string> = { food:"🍖", water:"💧", medicine:"💊", fuel:"⛽", ammo:"🔫", materials:"🔨" };
+  const labelMap: Record<"food"|"medicine"|"ammo", string> = { food:"Comida", medicine:"Medicina", ammo:"Munición" };
   return (
-    <div className="card bg-neutral-900 border-neutral-800 p-6">
-      <h3 className="text-xl font-bold mb-4">🏕️ Campamento</h3>
-      <div className="grid sm:grid-cols-3 md:grid-cols-6 gap-3">
-        {Object.entries(resources).map(([k,v])=>{
-          const isAmmo = k === 'ammo';
-          return (
-            <div
-              key={k}
-              className={`text-center p-3 rounded-xl bg-neutral-800 ${isAmmo ? 'cursor-pointer transition ' + (0 > 1 ? 'animate-pulse ring-2 ring-emerald-500 shadow-[0_0_12px_#10b981]' : '') : ''}`}
-              onClick={isAmmo ? (()=>{ if(0 > 1) setShowAmmoModal(true); }) : undefined}
-              title={isAmmo ? 'Gestionar munición' : undefined}
-            >
-              <div className="text-2xl mb-1">
-                {k==="food"?"🍖":k==="water"?"💧":k==="medicine"?"💊":k==="fuel"?"⛽":k==="ammo"?"🔫":"🔨"}
+    <>
+      <div className="card bg-neutral-900 border-neutral-800 p-6">
+        <h3 className="text-xl font-bold mb-4">🏕️ Campamento</h3>
+        <div className="grid sm:grid-cols-3 md:grid-cols-6 gap-3">
+          {Object.entries(resources).map(([k,v])=>{
+            if(k === 'food' || k === 'medicine' || k === 'ammo'){
+              return (
+                <CampTileButton
+                  key={k}
+                  icon={iconMap[k as keyof Resources]}
+                  label={labelMap[k as 'food'|'medicine'|'ammo']}
+                  value={v}
+                  onClick={()=>setOpenModal(k as "food"|"medicine"|"ammo")}
+                />
+              );
+            }
+            return (
+              <div key={k} className="text-center p-3 rounded-xl bg-neutral-800">
+                <div className="text-2xl mb-1">{iconMap[k as keyof Resources]}</div>
+                <div className="text-xl font-bold">{v}</div>
+                <div className="text-xs text-neutral-400">{k}</div>
               </div>
-              <div className="text-xl font-bold">{v}</div>
-              <div className="text-xs text-neutral-400">{k}</div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
+        <p className="mt-3 text-xs text-neutral-500">Total almacenado: {total}</p>
       </div>
-      <p className="mt-3 text-xs text-neutral-500">Total almacenado: {total}</p>
-    </div>
+      <Modal open={openModal === 'food'} title="Comida" onClose={()=>setOpenModal(null)}>
+        <p className="text-zinc-300">Contenido demo para comida.</p>
+      </Modal>
+      <Modal open={openModal === 'medicine'} title="Medicina" onClose={()=>setOpenModal(null)}>
+        <p className="text-zinc-300">Contenido demo para medicina.</p>
+      </Modal>
+      <Modal open={openModal === 'ammo'} title="Munición" onClose={()=>setOpenModal(null)}>
+        <p className="text-zinc-300">Contenido demo para munición.</p>
+      </Modal>
+    </>
   );
 }
 

--- a/src/components/CampTileButton.tsx
+++ b/src/components/CampTileButton.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+type Props = {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  onClick?: () => void;
+};
+
+export default function CampTileButton({ icon, label, value, onClick }: Props) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className="text-center p-3 rounded-xl bg-neutral-800 animate-breath transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
+    >
+      <div className="text-2xl mb-1">{icon}</div>
+      <div className="text-xl font-bold">{value}</div>
+      <div className="text-xs text-neutral-400">{label}</div>
+    </button>
+  );
+}
+

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useRef } from "react";
+
+export type ModalProps = {
+  open: boolean;
+  title?: string;
+  onClose: () => void;
+  children?: React.ReactNode;
+};
+
+export default function Modal({ open, title, onClose, children }: ModalProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    if (open) {
+      window.addEventListener("keydown", handleKey);
+      ref.current?.focus();
+    }
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-black/60 transition-opacity"
+        onClick={onClose}
+      />
+      <div className="fixed inset-0 flex items-center justify-center p-4">
+        <section
+          role="dialog"
+          aria-modal="true"
+          aria-label={title}
+          ref={ref}
+          tabIndex={-1}
+          data-open={open}
+          className="max-w-md w-[90%] rounded-2xl bg-zinc-900 p-5 ring-1 ring-zinc-800 shadow-xl scale-95 opacity-0 data-[open=true]:scale-100 data-[open=true]:opacity-100 transition"
+        >
+          <header className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold">{title}</h2>
+            <button
+              onClick={onClose}
+              className="px-3 py-1 rounded-md bg-zinc-800 hover:bg-zinc-700"
+            >
+              Cerrar
+            </button>
+          </header>
+          <div>{children}</div>
+        </section>
+      </div>
+    </>
+  );
+}
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,15 @@
 export default {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        breath: {
+          '0%, 100%': { transform: 'scale(1)', filter: 'brightness(1)' },
+          '50%': { transform: 'scale(1.03)', filter: 'brightness(1.05)' },
+        },
+      },
+      animation: { breath: 'breath 2.2s ease-in-out infinite' },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
- add `breath` keyframe and animation in Tailwind config
- introduce reusable `Modal` and `CampTileButton` components
- replace food, medicine and ammo tiles with animated buttons that open demo modals

## Testing
- `npm test`
- `npm run build` *(fails: [vite]: Rollup failed to resolve import "framer-motion" from BattleTicker.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c50a73ac7883259a15e039eb6f8a49