### PR TITLE
refactor: unify inventory consumption

### DIFF
--- a/src/systems/inventory.ts
+++ b/src/systems/inventory.ts
@@ -95,3 +95,8 @@ export function consumeMed(state: any, playerId: string, itemId: string): any {
   gameLog(`💊 ${player.name} usa ${item.name} (+${gain} PV).`);
   return { ...state, players };
 }
+
+// Backwards-compatibility aliases for legacy imports
+// (some modules may still expect these names)
+export const consumeFoodInventoryItem = consumeFood;
+export const consumeMedInventoryItem  = consumeMed;


### PR DESCRIPTION
## Summary
- add compatibility aliases for consumeFoodInventoryItem and consumeMedInventoryItem
- wire App to use inventory system for food and medicine consumption
- heal ally action now withdraws medicine from stock and consumes via inventory helpers

## Testing
- `npm test`
- `npm run test:game` *(fails: Cannot find module '/workspace/apocalipsis-zombieRPG/build/data/weapons')*

------
https://chatgpt.com/codex/tasks/task_e_68c5ea28c4cc83258c11cef091616d9d