### PR TITLE
feat: add continue overlay and overlay root shim

### DIFF
--- a/src/components/overlays/ContinueOverlay.tsx
+++ b/src/components/overlays/ContinueOverlay.tsx
@@ -1,19 +1,44 @@
-import { useEffect } from 'react';
+import { useEffect } from "react";
 
-export default function ContinueOverlay({ open, text, onContinue }:{
-  open:boolean; text?:string; onContinue:()=>void;
-}){
-  useEffect(()=>{
-    if(!open) return;
-    const onKey=(e:KeyboardEvent)=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); onContinue(); } };
-    window.addEventListener('keydown', onKey);
-    return ()=> window.removeEventListener('keydown', onKey);
-  },[open,onContinue]);
-  if(!open) return null;
+export default function ContinueOverlay({
+  open,
+  text,
+  onContinue,
+}: {
+  open: boolean;
+  text?: string;
+  onContinue: () => void;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onContinue();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onContinue]);
+
+  if (!open) return null;
+
   return (
     <div className="fixed inset-0 z-[9999] bg-black/70 flex items-center justify-center">
-      <button className="px-6 py-3 rounded-xl bg-white text-black font-semibold"
-              onClick={onContinue}>{text ?? 'Continuar ▸'}</button>
+      <div className="flex flex-col items-center gap-3">
+        {text ? (
+          <div className="text-white/80 text-sm max-w-[80vw] text-center">{text}</div>
+        ) : null}
+        <button
+          className="px-6 py-3 rounded-xl bg-white text-black font-semibold shadow"
+          onClick={onContinue}
+          aria-label="Continuar"
+        >
+          Continuar ▸
+        </button>
+        <div className="text-white/60 text-xs">Enter o Espacio para continuar</div>
+      </div>
     </div>
   );
 }
+

--- a/src/components/overlays/OverlayRoot.tsx
+++ b/src/components/overlays/OverlayRoot.tsx
@@ -1,0 +1,14 @@
+import ContinueOverlay from "./ContinueOverlay";
+
+export default function OverlayRoot({
+  overlayOpen,
+  proceed,
+  text,
+}: {
+  overlayOpen: boolean;
+  proceed: () => void;
+  text?: string;
+}) {
+  return <ContinueOverlay open={overlayOpen} text={text} onContinue={proceed} />;
+}
+

--- a/src/components/overlays/index.ts
+++ b/src/components/overlays/index.ts
@@ -1,0 +1,3 @@
+export { default as ContinueOverlay } from "./ContinueOverlay";
+export { default as OverlayRoot } from "./OverlayRoot";
+


### PR DESCRIPTION
## Summary
- add ContinueOverlay component with button and keyboard shortcuts
- add OverlayRoot shim to maintain existing import path and a barrel export

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c62f9b95a483259d5800aea6be6a1b