### PR TITLE
Improve eating and weapon handling

### DIFF
--- a/src/components/WeaponPicker.tsx
+++ b/src/components/WeaponPicker.tsx
@@ -1,7 +1,6 @@
-import React, { useMemo } from "react";
-import { getAvailableWeapons, WeaponOpt } from "../systems/combat/getAvailableWeapons";
-import { findWeaponById } from "../data/weapons";
-import { getAmmoFor, isRangedWeapon } from "../systems/weapons";
+import React from "react";
+import { WEAPONS } from "../data/weapons";
+import { playerOwnsWeapon } from "../systems/ammo";
 
 type WeaponPickerProps = {
   player: any;
@@ -9,29 +8,23 @@ type WeaponPickerProps = {
 };
 
 export default function WeaponPicker({ player, onSelect }: WeaponPickerProps) {
-  const weapons = useMemo<WeaponOpt[]>(() => getAvailableWeapons(player), [player]);
+  const options = [WEAPONS.find(w=>w.id==='fists')!];
+  if (playerOwnsWeapon(player, 'knife')) options.push(WEAPONS.find(w=>w.id==='knife')!);
+  if (playerOwnsWeapon(player, 'pistol9')) options.push(WEAPONS.find(w=>w.id==='pistol9')!);
 
   return (
     <div className="mt-3">
       <div className="text-sm opacity-80 mb-2">Seleccionar arma</div>
       <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
-        {weapons.map((w) => {
-          const wObj = findWeaponById(w.id);
-          const ranged = isRangedWeapon(wObj);
-          const ammo = ranged ? getAmmoFor(player, w.id) : null;
-          const noAmmo = ranged && (ammo ?? 0) <= 0;
-          return (
-            <button
-              key={w.id}
-              disabled={!w.usable}
-              title={noAmmo ? "No hay munición." : undefined}
-              onClick={() => w.usable && onSelect(w.id)}
-              className={`px-2 py-1 rounded border ${w.usable ? "border-slate-500" : "border-slate-700 opacity-50"}`}
-            >
-              {w.label}
-            </button>
-          );
-        })}
+        {options.map((w) => (
+          <button
+            key={w.id}
+            onClick={() => onSelect(w.id)}
+            className="px-2 py-1 rounded border border-slate-500"
+          >
+            {w.name}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/data/weapons.ts
+++ b/src/data/weapons.ts
@@ -13,6 +13,7 @@ export const WEAPONS: Weapon[] = [
   { id: 'fists',   name: 'Puños',           type: 'melee',  hitBonus: 0, damage: { times:1, faces:4, mod:0 }, usesAttr: 'Fuerza' },
   { id: 'knife',   name: 'Navaja',          type: 'melee',  hitBonus: 1, damage: { times:1, faces:6, mod:0 }, usesAttr: 'Fuerza' },
   { id: 'pistol',  name: 'Pistola',         type: 'ranged', hitBonus: 1, damage: { times:1, faces:6, mod:4 }, usesAttr: 'Destreza', ammoCost:1, magSize:15 },
+  { id: 'pistol9', name: 'Pistola 9mm',     type: 'ranged', hitBonus: 1, damage: { times:1, faces:8, mod:0 }, usesAttr: 'Destreza', ammoCost:1, magSize:12 },
   { id: 'smg',     name: 'Subfusil (SMG)',  type: 'ranged', hitBonus: 1, damage: { times:1, faces:6, mod:3 }, usesAttr: 'Destreza', ammoCost:1, magSize:30 },
   { id: 'shotgun', name: 'Escopeta',        type: 'ranged', hitBonus: 0, damage: { times:2, faces:4, mod:3 }, usesAttr: 'Destreza', ammoCost:1, magSize:5 },
   { id: 'rifle',   name: 'Rifle',           type: 'ranged', hitBonus: 2, damage: { times:1, faces:8, mod:4 }, usesAttr: 'Destreza', ammoCost:1, magSize:10 },

--- a/src/systems/actors.ts
+++ b/src/systems/actors.ts
@@ -1,0 +1,3 @@
+export function getEnergy(p:any){ return Number.isFinite(p?.energy) ? p.energy : 0; }
+export function getEnergyMax(p:any){ return Number.isFinite(p?.energyMax) ? p.energyMax : 100; }
+export function withEnergy(p:any, next:number){ return { ...p, energy: Math.max(0, Math.min(getEnergyMax(p), Math.floor(next))) }; }

--- a/src/systems/ammo.ts
+++ b/src/systems/ammo.ts
@@ -1,5 +1,6 @@
 import { getSelectedWeapon, isRangedWeapon } from "./weapons.js";
 import { WEAPONS } from "../data/weapons.js";
+import type { Weapon } from "../data/weapons.js";
 
 export type AmmoItem = { type:'ammo'; kind:'loose'|'box'; amount:number; name?:string; id?:string; bullets?:number; qty?:number; count?:number };
 
@@ -266,4 +267,23 @@ export function listReloadableWeapons(player:any): {id:string; name:string}[] {
     }
   }
   return list;
+}
+
+export function playerOwnsWeapon(player:any, weaponId:string){
+  const arr = [...(player?.inventory||[]), ...(player?.backpack||[])];
+  return arr.some(it => {
+    const n = norm(it?.name || it?.id || '');
+    return weaponId.includes('pistol') ? n.includes('pistola') : n.includes('navaja');
+  });
+}
+
+export function canReload(player:any, weapon:Weapon){
+  if (weapon.type!=='ranged' && weapon.type!=='firearm') return false;
+  const total = getTotalAmmoAvailable(player);
+  return total.total > 0;
+}
+
+export function equipWeapon(player:any, weaponId:string){
+  if (weaponId!=='fists' && !playerOwnsWeapon(player, weaponId)) return player;
+  return { ...player, equippedWeaponId: weaponId };
 }

--- a/src/systems/inventory.ts
+++ b/src/systems/inventory.ts
@@ -1,4 +1,5 @@
 import { FOOD_CATALOG, MED_CATALOG } from "../data/consumables";
+import { eat } from "./food";
 import { gameLog } from "../utils/logger";
 import type { CampState, FoodItem, InventoryItem, MedItem } from "../types/inventory";
 
@@ -71,12 +72,11 @@ export function consumeFood(state: any, playerId: string, itemId: string): any {
   const idx = player.inventory.findIndex((it:InventoryItem)=>it.id===itemId && it.type==='food');
   if (idx < 0) return state;
   const item = player.inventory[idx] as FoodItem;
-  const gain = Math.max(0, Math.min(item.energy, (player.energyMax ?? 100) - (player.energy ?? 0)));
+  const { player: afterEat } = eat(player, item);
   const inventory = [ ...player.inventory ];
   inventory.splice(idx,1);
   const players = [ ...state.players ];
-  players[pIdx] = { ...player, inventory, energy: (player.energy ?? 0) + gain };
-  gameLog(`🍽️ ${player.name} come ${item.name} (+${gain} energía).`);
+  players[pIdx] = { ...afterEat, inventory };
   return { ...state, players };
 }
 


### PR DESCRIPTION
## Summary
- Normalize player energy with new actor utilities and nightly recovery clamping
- Use robust nutrition lookup and atomic `eat` for food consumption with single log entry
- Add conditional weapon picker with 9mm pistol, reload gating and equipped-weapon enforcement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c634d1861c8325a1bcc5328ebe39e9