### PR TITLE
feat: add active player compatibility bridge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { clsx } from "clsx";
+import { setActivePlayerCompat } from "./compat/active-player-compat";
+import { useTurn } from "./state/turnStore";
 import { ITEMS_CATALOG } from "./data/items";
 import { GAME_NOTES, GameNote } from "./data/notes";
 import WelcomeOverlay from "./components/WelcomeOverlay";
@@ -584,7 +586,15 @@ export default function App(){
 
   const alivePlayers = players.filter(p => p.status !== "dead");
   const aliveEnemies = enemies;
-  const activePlayer = activePlayerId ? players.find(p => p.id === activePlayerId) ?? null : null;
+  const turn = useTurn?.();
+  const activePlayer = useMemo(() => {
+    const ps = turn?.players ?? players;
+    const id = turn?.currentActorId ?? activePlayerId;
+    return ps.find((p: any) => p?.id === id) ?? null;
+  }, [turn?.players, turn?.currentActorId, players, activePlayerId]);
+  useEffect(() => {
+    setActivePlayerCompat(activePlayer);
+  }, [activePlayer?.id]);
   const activeDown = !!activePlayer && activePlayer.hp <= 0;
   const canAttackWithSelected = (() => {
     const p = activePlayer;

--- a/src/compat/active-player-compat.ts
+++ b/src/compat/active-player-compat.ts
@@ -1,0 +1,13 @@
+// src/compat/active-player-compat.ts
+// Mantiene una referencia global al jugador activo para código legacy.
+declare global {
+  interface Window {
+    activePlayer?: any;
+    getActivePlayer?: () => any;
+  }
+}
+
+export function setActivePlayerCompat(player: any) {
+  (window as any).activePlayer = player ?? null;
+  (window as any).getActivePlayer = () => (window as any).activePlayer ?? null;
+}

--- a/src/compat/legacy-globals.ts
+++ b/src/compat/legacy-globals.ts
@@ -5,29 +5,41 @@ import { consumeMedicineFromPlayer } from "../systems/medicine";
 
 declare global {
   interface Window {
-    consumeFoodInventoryItem?: (player:any, amount:number)=>any;
-    consumeFoodForPlayer?: (player:any, amount:number)=>any;
-    consumeMedItem?: (player:any, amount:number)=>any;
-    consumeMedForPlayer?: (player:any, amount:number)=>any;
+    consumeFoodInventoryItem?: (player?: any, amount?: number) => any;
+    consumeFoodForPlayer?: (player?: any, amount?: number) => any;
+    consumeMedItem?: (player?: any, amount?: number) => any;
+    consumeMedForPlayer?: (player?: any, amount?: number) => any;
+    activePlayer?: any;
+    getActivePlayer?: () => any;
   }
 }
 
-(function installLegacyGlobals(){
+(function installLegacyGlobals() {
   const g = window as any;
-  const wrap = (fn:(p:any,n:number)=>any, tag:string) =>
-    (p:any, n:number=1) => {
-      console.warn(`[compat] ${tag} llamado`, { n });
-      try { return fn(p, n); } catch(e){ console.error(`[compat] fallo ${tag}`, e); return { player:p, taken:0 }; }
+  const withFallback = (fn: (p: any, n: number) => any, tag: string) =>
+    (p?: any, n?: number) => {
+      const player = p ?? g.activePlayer ?? (g.getActivePlayer?.() ?? null);
+      const amount = Number.isFinite(n) ? (n as number) : 1;
+      if (!player) {
+        console.warn(`[compat] ${tag}: no hay activePlayer disponible; operación ignorada.`);
+        return { player: null, taken: 0 };
+      }
+      try {
+        return fn(player, amount);
+      } catch (e) {
+        console.error(`[compat] fallo ${tag}`, e);
+        return { player, taken: 0 };
+      }
     };
 
   if (typeof g.consumeFoodInventoryItem !== "function")
-    g.consumeFoodInventoryItem = wrap(consumeFoodFromPlayer, "consumeFoodInventoryItem");
+    g.consumeFoodInventoryItem = withFallback(consumeFoodFromPlayer, "consumeFoodInventoryItem");
   if (typeof g.consumeFoodForPlayer !== "function")
-    g.consumeFoodForPlayer = wrap(consumeFoodFromPlayer, "consumeFoodForPlayer");
+    g.consumeFoodForPlayer = withFallback(consumeFoodFromPlayer, "consumeFoodForPlayer");
   if (typeof g.consumeMedItem !== "function")
-    g.consumeMedItem = wrap(consumeMedicineFromPlayer, "consumeMedItem");
+    g.consumeMedItem = withFallback(consumeMedicineFromPlayer, "consumeMedItem");
   if (typeof g.consumeMedForPlayer !== "function")
-    g.consumeMedForPlayer = wrap(consumeMedicineFromPlayer, "consumeMedForPlayer");
+    g.consumeMedForPlayer = withFallback(consumeMedicineFromPlayer, "consumeMedForPlayer");
 })();
 
 export {};


### PR DESCRIPTION
## Summary
- expose active player on `window` and helper to update it
- let legacy consume wrappers fallback to the active player
- publish current actor from `App` using `useTurn`

## Testing
- `npm test`
- `npm run build` *(fails: Rollup failed to resolve import "zustand" from src/state/turnStore.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c637d4c9588325942733dc3579100e