### PR TITLE
refactor: unify turn state with zustand and auto enemy phase

### DIFF
--- a/src/state/turnStore.ts
+++ b/src/state/turnStore.ts
@@ -1,80 +1,125 @@
 // src/state/turnStore.ts
-import { create } from "zustand";
+import { create } from 'zustand';
 
-export type Phase = "out_of_combat" | "players" | "enemies";
-export type Actor = { id: string; name: string; hp: number; hpMax: number; def: number; atk: number };
+export type Phase = 'out_of_combat' | 'players' | 'enemies';
 
-type TurnState = {
+export type Actor = {
+  id: string;
+  name: string;
+  hp: number;
+  hpMax: number;
+  def: number;
+  atk: number;
+  energy: number;
+  energyMax: number;
+  defense?: number;
+  conditions?: any;
+  profession?: string;
+  inventory: any[];
+  backpack?: any[];
+  equippedWeaponId?: string;
+  ammoByWeapon?: Record<string, number>;
+};
+
+export type TurnState = {
   phase: Phase;
   round: number;
-  order: string[];
   index: number;
   lock: boolean;
   players: Actor[];
   enemies: Actor[];
 };
 
-type TurnAPI = {
+export type TurnAPI = {
   startCombat(players: Actor[], enemies: Actor[]): void;
   endCombat(): void;
-  endTurn(): void;
   currentActorId(): string | null;
   isEnemyPhase(): boolean;
+  endTurn(): void;
   setLock(v: boolean): void;
 };
 
+// helper to ensure defaults
+function normalizeActor(a: Actor): Actor {
+  return {
+    equippedWeaponId: 'fists',
+    ammoByWeapon: {},
+    inventory: [],
+    energy: 0,
+    energyMax: 0,
+    ...a,
+    equippedWeaponId: a.equippedWeaponId ?? 'fists',
+    ammoByWeapon: a.ammoByWeapon ?? {},
+  };
+}
+
 export const useTurn = create<TurnState & TurnAPI>((set, get) => ({
-  phase: "out_of_combat",
+  phase: 'out_of_combat',
   round: 0,
-  order: [],
   index: 0,
   lock: false,
   players: [],
   enemies: [],
 
   startCombat(players, enemies) {
-    const order = [...players.map(p => p.id), ...enemies.map(e => e.id)];
-    set({ phase: "players", round: 1, order, index: 0, players, enemies, lock: false });
+    set({
+      players: players.map(normalizeActor),
+      enemies: enemies.map(normalizeActor),
+      phase: 'players',
+      round: 1,
+      index: 0,
+      lock: false,
+    });
   },
 
   endCombat() {
-    set({ phase: "out_of_combat", order: [], index: 0, enemies: [], lock: false });
-  },
-
-  endTurn() {
-    const { phase, order, index, enemies, players } = get();
-    if (phase === "players") {
-      // avanzar a siguiente jugador vivo; si no quedan, fase enemigos
-      const nextIndex = index + 1;
-      const playersCount = players.filter(p => p.hp > 0).length;
-      if (nextIndex < playersCount) {
-        set({ index: nextIndex });
-      } else {
-        set({ phase: "enemies", index: 0 });
-      }
-    } else if (phase === "enemies") {
-      // fin de ronda -> vuelve a jugadores
-      set((s) => ({ phase: "players", index: 0, round: s.round + 1 }));
-    }
+    set({ phase: 'out_of_combat', players: [], enemies: [], round: 0, index: 0, lock: false });
   },
 
   currentActorId() {
-    const { phase, order, index, players, enemies } = get();
-    if (phase === "players") {
-      const alivePlayers = players.filter(p => p.hp > 0);
-      return alivePlayers[index]?.id ?? null;
+    const { phase, players, enemies, index } = get();
+    if (phase === 'players') {
+      const alive = players.filter((p) => p.hp > 0);
+      return alive[index]?.id ?? null;
     }
-    if (phase === "enemies") {
-      const aliveEnemies = enemies.filter(e => e.hp > 0);
-      return aliveEnemies[index]?.id ?? null;
+    if (phase === 'enemies') {
+      const alive = enemies.filter((e) => e.hp > 0);
+      return alive[index]?.id ?? null;
     }
     return null;
   },
 
   isEnemyPhase() {
-    return get().phase === "enemies";
+    return get().phase === 'enemies';
   },
 
-  setLock(v) { set({ lock: v }); }
-}));
+  endTurn() {
+    const { phase, players, enemies, index } = get();
+    if (phase === 'players') {
+      const alive = players.filter((p) => p.hp > 0);
+      const next = index + 1;
+      if (next < alive.length) {
+        set({ index: next });
+        return;
+      }
+      // enemy phase
+      set({ phase: 'enemies', index: 0 });
+      const aliveEnemies = enemies.filter((e) => e.hp > 0);
+      let curPlayers = [...players];
+      for (const enemy of aliveEnemies) {
+        const targets = curPlayers.filter((p) => p.hp > 0);
+        if (!targets.length) break;
+        const target = targets[Math.floor(Math.random() * targets.length)];
+        const dmg = Math.max(1, enemy.atk);
+        curPlayers = curPlayers.map((p) =>
+          p.id === target.id ? { ...p, hp: Math.max(0, p.hp - dmg) } : p
+        );
+      }
+      set((s) => ({ players: curPlayers, phase: 'players', round: s.round + 1, index: 0 }));
+    }
+  },
 
+  setLock(v) {
+    set({ lock: v });
+  },
+}));


### PR DESCRIPTION
## Summary
- overhaul turn store to track combat phase, actors and locking
- support automatic enemy rounds and default weapon/ammo state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c643376990832591e2e790e3334127