### PR TITLE
Restore out-of-combat UI elements

### DIFF
--- a/src/components/combat/WeaponSelector.tsx
+++ b/src/components/combat/WeaponSelector.tsx
@@ -1,6 +1,12 @@
 import { playerOwnsWeapon } from '../../systems/weapons';
 
-export default function WeaponSelector({ player, onEquip }:{ player:any; onEquip:(weaponId:string)=>void }){
+type WeaponSelectorProps = {
+  player: any;
+  onEquip: (weaponId: string) => void;
+};
+
+export default function WeaponSelector({ player, onEquip }: WeaponSelectorProps) {
+  if (!player) return null;
   const options = [
     { id:'fists',   label:'Puños' },
     ...(playerOwnsWeapon(player,'knife')   ? [{ id:'knife',   label:'Navaja' }]   : []),

--- a/src/systems/combat/getAvailableWeapons.ts
+++ b/src/systems/combat/getAvailableWeapons.ts
@@ -31,22 +31,36 @@ const ALIAS: Record<string, string[]> = {
   smg: ["smg","subfusil","subfusil (smg)"],
 };
 
+function collectCandidateStrings(entry: any): string[] {
+  const values: string[] = [];
+  const push = (value: any) => {
+    if (!value) return;
+    if (typeof value === "string" || typeof value === "number") {
+      values.push(String(value));
+      return;
+    }
+    if (typeof value === "object") {
+      if (typeof value.string === "string") values.push(value.string);
+      if (typeof value.name === "string") values.push(value.name);
+      if (typeof value.label === "string") values.push(value.label);
+      if (typeof value.type === "string") values.push(value.type);
+    }
+  };
+  push(entry);
+  push(entry?.id);
+  push(entry?.name);
+  push(entry?.type);
+  push(entry?.string);
+  return values.map(norm);
+}
+
 /** ¿El inventario contiene alguno de los alias dados? */
 function hasAny(p: Player, keys: string[]): boolean {
   if (!Array.isArray(p.inventory)) return false;
+  const tokens = keys.map(norm);
   return p.inventory.some((it: any) => {
-    const parts = [
-      typeof it === "string" ? it : undefined,
-      it?.id,
-      it?.name,
-      it?.type,
-    ]
-      .filter(Boolean)
-      .map(norm);
-    return keys.some(k => {
-      const token = norm(k);
-      return parts.some(v => v.includes(token));
-    });
+    const parts = collectCandidateStrings(it);
+    return tokens.some(token => parts.some(value => value === token || value.includes(token)));
   });
 }
 


### PR DESCRIPTION
## Summary
- derive the active survivor depending on combat state and auto-equip melee when firearms run empty
- restore the combat log and weapon selector to the top of the out-of-combat layout and wire quick-equip handling in cards
- make weapon detection resilient to object inventory entries and guard the selector when no player is present

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c86064b214832591c52cdddbcb3842