### PR TITLE
feat: reorganiza la interfaz con log unificado y tabs combinadas

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -19,7 +19,7 @@
   @apply bg-gradient-to-br from-purple-950/40 to-black border-purple-800;
 }
 .btn {
-  @apply px-4 py-2 rounded-lg font-semibold transition-all;
+  @apply px-3 py-1 rounded bg-neutral-800 text-sm text-neutral-100 transition-colors hover:bg-neutral-700;
 }
 .btn-ghost {
   @apply bg-neutral-900 hover:bg-neutral-800 border border-neutral-700;
@@ -33,8 +33,17 @@
 .btn-green {
   @apply bg-green-900 hover:bg-green-800;
 }
+.btn-primary {
+  @apply px-3 py-1 rounded bg-neutral-100 text-neutral-900 font-semibold;
+}
 .badge {
   @apply px-2 py-1 rounded text-xs bg-neutral-900 border border-neutral-800;
 }
 .scrollbar-hide::-webkit-scrollbar { display:none }
 .scrollbar-hide { scrollbar-width: none; -ms-overflow-style: none; }
+.tab {
+  @apply px-4 py-2 text-sm text-neutral-300 transition-colors hover:bg-neutral-800;
+}
+.tab.active {
+  @apply border-b-2 border-neutral-100 text-neutral-100;
+}

--- a/src/systems/logger.ts
+++ b/src/systems/logger.ts
@@ -1,0 +1,43 @@
+let logEl: HTMLElement | null = null
+const pending: string[] = []
+const MAX_ENTRIES = 400
+
+function ensureLogger(selector = '#gameLog') {
+  if (logEl && document.contains(logEl)) return logEl
+  logEl = document.querySelector<HTMLElement>(selector)
+  return logEl
+}
+
+function pushMessage(message: string) {
+  if (!logEl) return
+  const entry = document.createElement('div')
+  entry.textContent = message
+  logEl.appendChild(entry)
+  if (logEl.children.length > MAX_ENTRIES) {
+    logEl.removeChild(logEl.firstChild as ChildNode)
+  }
+  logEl.scrollTop = logEl.scrollHeight
+}
+
+export function initLogger(selector = '#gameLog') {
+  logEl = typeof selector === 'string' ? document.querySelector<HTMLElement>(selector) : (selector as HTMLElement | null)
+  if (logEl && pending.length) {
+    const queued = [...pending]
+    pending.length = 0
+    queued.forEach(pushMessage)
+  }
+}
+
+export function appendLog(message: string) {
+  if (!ensureLogger()) {
+    pending.push(message)
+    return
+  }
+  if (pending.length) {
+    const queued = [...pending, message]
+    pending.length = 0
+    queued.forEach(pushMessage)
+    return
+  }
+  pushMessage(message)
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,5 @@
+import { appendLog } from "../systems/logger";
+
 export type LogFn = (msg: string) => void;
 export type TimeFn = () => string;
 
@@ -25,7 +27,9 @@ export function registerTimeProvider(fn: TimeFn) {
 export function gameLog(message: string) {
   try {
     const stamp = timeProvider();
-    currentLogger(`[${stamp}] ${message}`);
+    const line = `[${stamp}] ${message}`;
+    appendLog(line);
+    currentLogger(line);
   } catch {
     // no-op para no romper el runtime
   }


### PR DESCRIPTION
## Summary
- reorganize App layout into the new grid-based interface with head bar, card controls, modal overlay, combat panel, controls row, survivors grid, notes panel, unified camp tabs and notifications log
- add inventory tab panel, notes panel, camp tabs and resource tab to consolidate inventory, camp, and repair functionality
- introduce a DOM-based logger utility and hook game logging through it while updating shared button/tab styles
- restore the NoCardActions fallback so the cards board renders safely when no card is active

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8a51f229c8325b85e4bb33003aeaa